### PR TITLE
Feat: Add -fail-on-warns support

### DIFF
--- a/check-breaking/action.yml
+++ b/check-breaking/action.yml
@@ -1,20 +1,25 @@
-name: 'OpenAPI Spec: check for breaking API changes'
-description: 'Detect breaking changes in OpenAPI Specification 3'
+name: "OpenAPI Spec: check for breaking API changes"
+description: "Detect breaking changes in OpenAPI Specification 3"
 inputs:
   base:
-    description: 'Path of original OpenAPI spec in YAML or JSON format'
+    description: "Path of original OpenAPI spec in YAML or JSON format"
     required: true
   revision:
-    description: 'Path of revised OpenAPI spec in YAML or JSON format'
+    description: "Path of revised OpenAPI spec in YAML or JSON format"
     required: true
   fail-on-diff:
-    description: 'Fail with exit code 1 if a difference is found'
+    description: "Fail with exit code 1 if any ERR-level breaking changes are found"
     required: false
     default: true
+  fail-on-warns:
+    description: "Fail with exit code 1 if any WARN-level breaking changes are found"
+    required: false
+    default: false
 runs:
-  using: 'docker'
-  image: 'Dockerfile'
+  using: "docker"
+  image: "Dockerfile"
   args:
     - ${{ inputs.base }}
     - ${{ inputs.revision }}
     - ${{ inputs.fail-on-diff }}
+    - ${{ inputs.fail-on-warns }}

--- a/check-breaking/entrypoint.sh
+++ b/check-breaking/entrypoint.sh
@@ -3,9 +3,13 @@
 readonly base="$1"
 readonly revision="$2"
 readonly fail_on_diff="$3"
+readonly fail_on_warns="$4"
 
-echo "running oasdiff check for breaking-changes... base: $base, revision: $revision, fail_on_diff: $fail_on_diff"
-oasdiff -check-breaking -fail-on-diff -base "$base" -revision "$revision"
+echo "running oasdiff check for breaking-changes... base: $base, revision: $revision, fail_on_diff: $fail_on_diff, fail_on_warns: $fail_on_warns"
+
+readonly fail_on_warns_argument=$(if [ "$fail_on_warns" = "true" ]; then echo "-fail-on-warns"; fi)
+
+oasdiff -check-breaking -fail-on-diff -base "$base" -revision "$revision" "$fail_on_warns_argument"
 if [ $? != 0 ] && [ "$fail_on_diff" = "true"  ]; then
   exit 1
 fi


### PR DESCRIPTION
This adds `-fail-on-warns` support, which would fix the issue here https://github.com/oasdiff/oasdiff-action/issues/5.
I thought that `-fail-on-diff` triggered those, but it is not true.