### PR TITLE
Extend breaking action to accept optional breaking checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,22 @@ Copy and paste the following snippet into your build .yml file:
     fail-on-diff: true
 ```
 
+#### Include optional breaking change checks
+In order to ensure even stricter breaking policies, oasdiff provides with a few optional checks.
+Complete list can be found [here](https://github.com/Tufin/oasdiff/blob/main/BREAKING-CHANGES.md#optional-breaking-changes-checks).
+
+These checks can be added by filling the `include-checks` argument in the action like the following:
+```
+- name: Running OpenAPI Spec diff action
+  id: test_ete
+  uses: oasdiff/oasdiff-action/check-breaking@main
+  with:
+    base: https://raw.githubusercontent.com/Tufin/oasdiff/main/data/openapi-test1.yaml
+    revision: https://raw.githubusercontent.com/Tufin/oasdiff/main/data/openapi-test3.yaml
+    fail-on-diff: true
+    include-checks: "response-non-success-status-removed,api-operation-id-removed"
+```
+
 ### Generate a changelog
 Copy and paste the following snippet into your build .yml file:
 ```

--- a/check-breaking/action.yml
+++ b/check-breaking/action.yml
@@ -11,6 +11,9 @@ inputs:
     description: 'Fail with exit code 1 if any breaking changes are found'
     required: false
     default: 'true'
+  include-checks:
+    description: 'Include any of the defined optional breaking changes checks'
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -18,3 +21,4 @@ runs:
     - ${{ inputs.base }}
     - ${{ inputs.revision }}
     - ${{ inputs.fail-on-diff }}
+    - ${{ inputs.include-checks }}

--- a/check-breaking/entrypoint.sh
+++ b/check-breaking/entrypoint.sh
@@ -1,15 +1,28 @@
-#!/bin/sh
+#!/bin/bash
 
 readonly base="$1"
 readonly revision="$2"
 readonly fail_on_diff="$3"
+readonly include_checks="$4"
 
-echo "running oasdiff breaking base: $base, revision: $revision, fail_on_diff: $fail_on_diff"
+echo "running oasdiff breaking base: $base, revision: $revision, fail_on_diff: $fail_on_diff, include_checks: $include_checks"
 
 set -o pipefail
 
+# Build flags to pass in command
+flags=""
 if [[ $fail_on_diff = "true" ]]; then
-  oasdiff breaking "$base" "$revision" --fail-on WARN
+  flags+="--fail-on WARN "
+fi
+
+if [[ -n $include_checks ]]; then
+  flags+="--include-checks $include_checks "
+fi
+echo "flags: $flags"
+
+# Run command
+if [[ -n $flags ]]; then
+  oasdiff breaking "$base" "$revision" $flags
 else
   oasdiff breaking "$base" "$revision"
 fi


### PR DESCRIPTION
This PR extends the breaking action to add the ability to pass in optional breaking checks to oasdiff tool. The list of optional checks that can be added can be found [here](https://github.com/Tufin/oasdiff/blob/main/BREAKING-CHANGES.md#optional-breaking-changes-checks).

Changes have been tested by running the `entrypoint.sh` with the different options. 