### PR TITLE
Fix breaking action to use POSIX sh compatible syntax

### DIFF
--- a/breaking/entrypoint.sh
+++ b/breaking/entrypoint.sh
@@ -9,15 +9,15 @@ echo "running oasdiff breaking base: $base, revision: $revision, fail_on_diff: $
 
 # Build flags to pass in command
 flags=""
-if [[ $fail_on_diff = "true" ]]; then
-    flags+="--fail-on WARN "
+if [ "$fail_on_diff" = "true" ]; then
+    flags="${flags} --fail-on WARN"
 fi
-if [[ ! -z $include_checks ]]; then
-    flags+="--include-checks $include_checks "
+if [ -n "$include_checks" ]; then
+    flags="${flags} --include-checks $include_checks"
 fi
 echo "flags: $flags"
 
-if [[ -n $flags ]]; then
+if [ -n "$flags" ]; then
     oasdiff breaking "$base" "$revision" $flags
 else
     oasdiff breaking "$base" "$revision"


### PR DESCRIPTION
Fixes the action when passing in `fail-on-diff: true` as well as any `include-checks`, as the script is running with plain `sh` however the entrypoint script is using bash specific syntax.

This PR swaps the bash specific syntax with POSIX sh compatible syntax, and also adds tests for these cases via github action jobs.
Runs: https://github.com/promeris/oasdiff-action/actions/runs/5853886299