### PR TITLE
feat: share oasdiff output

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+
+[*.sh]
+indent_size = 4
+
+[*.yaml]
+indent_size = 2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-name: 'Test OpenAPI Spec Diff Action'
+name: "Test OpenAPI Spec Diff Action"
 on:
   pull_request:
   push:
@@ -7,15 +7,15 @@ jobs:
     runs-on: ubuntu-latest
     name: A job to test OpenAPI Spec diff action
     steps:
-        - name: checkout
-          uses: actions/checkout@v3
-        - name: Running OpenAPI Spec diff action
-          id: test_ete
-          uses: ./diff
-          with:
-            base: 'specs/base.yaml'
-            revision: 'specs/revision.yaml'
-            format: 'text'
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: Running OpenAPI Spec diff action
+        id: test_ete
+        uses: ./diff
+        with:
+          base: "specs/base.yaml"
+          revision: "specs/revision.yaml"
+          format: "text"
   oas_diff_breaking_changes_job:
     runs-on: ubuntu-latest
     name: A job to test OpenAPI Spec breaking changes
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Running OpenAPI Spec changelog tag action
         id: test_changelog
-        uses: oasdiff/oasdiff-action/changelog@v0.0.10
+        uses: ./changelog
         with:
           base: https://raw.githubusercontent.com/Tufin/oasdiff/main/data/openapi-test1.yaml
           revision: https://raw.githubusercontent.com/Tufin/oasdiff/main/data/openapi-test3.yaml

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-name: "Test OpenAPI Spec Diff Action"
+name: 'Test OpenAPI Spec Diff Action'
 on:
   pull_request:
   push:
@@ -13,9 +13,20 @@ jobs:
         id: test_ete
         uses: ./diff
         with:
-          base: "specs/base.yaml"
-          revision: "specs/revision.yaml"
-          format: "text"
+          base: 'specs/base.yaml'
+          revision: 'specs/revision.yaml'
+          format: 'text'
+      - name: Test output
+        run: |
+          delimiter=$(cat /proc/sys/kernel/random/uuid | tr -d '-')
+          output=$(cat <<-$delimiter
+          ${{ steps.test_ete.outputs.diff }}
+          $delimiter
+          )
+          if [ -z "$output" ]; then
+            echo "Missing output from action" >&2
+            exit 1
+          fi
   oas_diff_breaking_changes_job:
     runs-on: ubuntu-latest
     name: A job to test OpenAPI Spec breaking changes
@@ -29,6 +40,17 @@ jobs:
           base: https://raw.githubusercontent.com/Tufin/oasdiff/main/data/openapi-test1.yaml
           revision: https://raw.githubusercontent.com/Tufin/oasdiff/main/data/openapi-test3.yaml
           fail-on-diff: false
+      - name: Test output
+        run: |
+          delimiter=$(cat /proc/sys/kernel/random/uuid | tr -d '-')
+          output=$(cat <<-$delimiter
+          ${{ steps.test_breaking_changes.outputs.breaking }}
+          $delimiter
+          )
+          if [ -z "$output" ]; then
+            echo "Missing output from action" >&2
+            exit 1
+          fi
   oas_diff_changelog_tag_job:
     runs-on: ubuntu-latest
     name: A job to test tag release of OpenAPI Spec changelog action
@@ -41,3 +63,14 @@ jobs:
         with:
           base: https://raw.githubusercontent.com/Tufin/oasdiff/main/data/openapi-test1.yaml
           revision: https://raw.githubusercontent.com/Tufin/oasdiff/main/data/openapi-test3.yaml
+      - name: Test output
+        run: |
+          delimiter=$(cat /proc/sys/kernel/random/uuid | tr -d '-')
+          output=$(cat <<-$delimiter
+          ${{ steps.test_changelog.outputs.changelog }}
+          $delimiter
+          )
+          if [ -z "$output" ]; then
+            echo "Missing output from action" >&2
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -11,9 +11,12 @@ Copy and paste the following snippet into your build .yml file:
 ```
 - name: Running OpenAPI Spec diff action
   uses: oasdiff/oasdiff-action/diff@main
+  id: oasdiff
   with:
     base: 'specs/base.yaml'
     revision: 'specs/revision.yaml'
+
+# Followup steps can use the output and share on Slack, S3, etc: ${{ steps.oasdiff.outputs.diff }}
 ```
 
 This action supports additional arguments that are converted to parameters for the `oasdiff` CLI.
@@ -24,7 +27,7 @@ This action supports additional arguments that are converted to parameters for t
 | --format | format | yaml |
 | --include-path-params | include-path-params | false |
 
-Available outputs: `diff`
+This action provides the diff as a GitHub step output named: `diff`
 
 ### Check for breaking API changes, and fail if any are found
 Copy and paste the following snippet into your build .yml file:
@@ -44,7 +47,7 @@ Additional arguments:
 | --include-checks      | include-checks | csv |
 | --include-path-params | include-path-params | false |
 
-Available outputs: `breaking`
+This action also provides the breaking changes as a GitHub step output named: `breaking`
 
 ### Generate a changelog
 Copy and paste the following snippet into your build .yml file:
@@ -62,4 +65,4 @@ Additional arguments:
 |--------|--------|--------|
 | --include-path-params | include-path-params | false |
 
-Available outputs: `changelog`
+This action also provides the changelog as a GitHub step output named: `changelog`

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ This action supports additional arguments that are converted to parameters for t
 | --format | format | yaml |
 | --include-path-params | include-path-params | false |
 
+Available outputs: `diff`
+
 ### Check for breaking API changes, and fail if any are found
 Copy and paste the following snippet into your build .yml file:
 ```
@@ -42,6 +44,7 @@ Additional arguments:
 | --include-checks      | include-checks | csv |
 | --include-path-params | include-path-params | false |
 
+Available outputs: `breaking`
 
 ### Generate a changelog
 Copy and paste the following snippet into your build .yml file:
@@ -58,3 +61,5 @@ Additional arguments:
 | CLI | Action input | Default |
 |--------|--------|--------|
 | --include-path-params | include-path-params | false |
+
+Available outputs: `changelog`

--- a/breaking/Dockerfile
+++ b/breaking/Dockerfile
@@ -1,4 +1,5 @@
 FROM tufin/oasdiff:main
+RUN apk add --no-cache expect
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/breaking/action.yml
+++ b/breaking/action.yml
@@ -18,6 +18,9 @@ inputs:
     description: 'Include path parameter names in endpoint matching'
     required: false
     default: 'false'
+outputs:
+  breaking:
+    description: 'Details from breaking changes, both "error" and "warn"'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/breaking/entrypoint.sh
+++ b/breaking/entrypoint.sh
@@ -23,9 +23,9 @@ fi
 echo "flags: $flags"
 
 if [ -n "$flags" ]; then
-    OUTPUT=$(oasdiff breaking "$base" "$revision" $flags)
+    OUTPUT=$(unbuffer oasdiff breaking "$base" "$revision" $flags)
 else
-    OUTPUT=$(oasdiff breaking "$base" "$revision")
+    OUTPUT=$(unbuffer oasdiff breaking "$base" "$revision")
 fi
 
 echo "$OUTPUT"
@@ -39,6 +39,9 @@ if [ "$SIZE" -ge "1000000" ]; then
 fi
 
 DELIMITER=$(cat /proc/sys/kernel/random/uuid | tr -d '-')
+
+# Remove ANSI color codes
+OUTPUT=$(echo "$OUTPUT" | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2};?)?)?[mGK]//g")
 
 echo "breaking<<$DELIMITER" >>$GITHUB_OUTPUT
 echo "$OUTPUT" >>$GITHUB_OUTPUT

--- a/breaking/entrypoint.sh
+++ b/breaking/entrypoint.sh
@@ -23,30 +23,32 @@ fi
 echo "flags: $flags"
 
 if [ -n "$flags" ]; then
-    OUTPUT=$(unbuffer oasdiff breaking "$base" "$revision" $flags)
+    output=$(unbuffer oasdiff breaking "$base" "$revision" $flags)
 else
-    OUTPUT=$(unbuffer oasdiff breaking "$base" "$revision")
+    output=$(unbuffer oasdiff breaking "$base" "$revision")
 fi
 
-echo "$OUTPUT"
+echo "$output"
 
 # GitHub Actions limits output to 1MB
 # We count bytes because unicode has multibyte characters
-SIZE=$(echo "$OUTPUT" | wc -c)
-if [ "$SIZE" -ge "1000000" ]; then
+size=$(echo "$output" | wc -c)
+if [ "$size" -ge "1000000" ]; then
     echo "WARN: Diff exceeds the 1MB limit, truncating output..." >&2
-    OUTPUT=$(echo "$OUTPUT" | head -c $LIMIT)
+    output=$(echo "$output" | head -c $1000000)
 fi
 
-DELIMITER=$(cat /proc/sys/kernel/random/uuid | tr -d '-')
+delimiter=$(cat /proc/sys/kernel/random/uuid | tr -d '-')
 
 # Remove ANSI color codes
-OUTPUT=$(echo "$OUTPUT" | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2};?)?)?[mGK]//g")
+output=$(echo "$output" | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2};?)?)?[mGK]//g")
 
-echo "breaking<<$DELIMITER" >>$GITHUB_OUTPUT
-echo "$OUTPUT" >>$GITHUB_OUTPUT
-echo "$DELIMITER" >>$GITHUB_OUTPUT
+echo "breaking<<$delimiter" >>$GITHUB_OUTPUT
+[ -n "$output" ] && echo "$output" >>$GITHUB_OUTPUT
+[ -z "$output" ] && echo "No breaking changes" >>$GITHUB_OUTPUT
+echo "$delimiter" >>$GITHUB_OUTPUT
 
 echo '```' >>$GITHUB_STEP_SUMMARY
-echo "$OUTPUT" >>$GITHUB_STEP_SUMMARY
+[ -n "$output" ] && echo "$output" >>$GITHUB_STEP_SUMMARY
+[ -z "$output" ] && echo "No breaking changes" >>$GITHUB_STEP_SUMMARY
 echo '```' >>$GITHUB_STEP_SUMMARY

--- a/breaking/entrypoint.sh
+++ b/breaking/entrypoint.sh
@@ -44,11 +44,17 @@ delimiter=$(cat /proc/sys/kernel/random/uuid | tr -d '-')
 output=$(echo "$output" | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2};?)?)?[mGK]//g")
 
 echo "breaking<<$delimiter" >>$GITHUB_OUTPUT
-[ -n "$output" ] && echo "$output" >>$GITHUB_OUTPUT
-[ -z "$output" ] && echo "No breaking changes" >>$GITHUB_OUTPUT
+if [ -n "$output" ]; then
+    echo "$output" >>$GITHUB_OUTPUT
+else
+    echo "No breaking changes" >>$GITHUB_OUTPUT
+fi
 echo "$delimiter" >>$GITHUB_OUTPUT
 
 echo '```' >>$GITHUB_STEP_SUMMARY
-[ -n "$output" ] && echo "$output" >>$GITHUB_STEP_SUMMARY
-[ -z "$output" ] && echo "No breaking changes" >>$GITHUB_STEP_SUMMARY
+if [ -n "$output" ]; then
+    echo "$output" >>$GITHUB_STEP_SUMMARY
+else
+    echo "No breaking changes" >>$GITHUB_STEP_SUMMARY
+fi
 echo '```' >>$GITHUB_STEP_SUMMARY

--- a/changelog/Dockerfile
+++ b/changelog/Dockerfile
@@ -1,4 +1,5 @@
 FROM tufin/oasdiff:main
+RUN apk add --no-cache expect
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/changelog/action.yml
+++ b/changelog/action.yml
@@ -11,6 +11,9 @@ inputs:
     description: 'Include path parameter names in endpoint matching'
     required: false
     default: 'false'
+outputs:
+  changelog:
+    description: 'Details of all changes in the OpenAPI spec, "info", "warn" and "error"'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/changelog/entrypoint.sh
+++ b/changelog/entrypoint.sh
@@ -17,30 +17,32 @@ echo "flags: $flags"
 set -o pipefail
 
 if [ -n "$flags" ]; then
-    OUTPUT=$(unbuffer oasdiff changelog "$base" "$revision" $flags)
+    output=$(unbuffer oasdiff changelog "$base" "$revision" $flags)
 else
-    OUTPUT=$(unbuffer oasdiff changelog "$base" "$revision")
+    output=$(unbuffer oasdiff changelog "$base" "$revision")
 fi
 
-echo "$OUTPUT"
+echo "$output"
 
 # GitHub Actions limits output to 1MB
 # We count bytes because unicode has multibyte characters
-SIZE=$(echo "$OUTPUT" | wc -c)
-if [ "$SIZE" -ge "1000000" ]; then
+size=$(echo "$output" | wc -c)
+if [ "$size" -ge "1000000" ]; then
     echo "WARN: Diff exceeds the 1MB limit, truncating output..." >&2
-    OUTPUT=$(echo "$OUTPUT" | head -c $LIMIT)
+    output=$(echo "$output" | head -c $1000000)
 fi
 
-DELIMITER=$(cat /proc/sys/kernel/random/uuid | tr -d '-')
+delimiter=$(cat /proc/sys/kernel/random/uuid | tr -d '-')
 
 # Remove ANSI color codes
-OUTPUT=$(echo "$OUTPUT" | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2};?)?)?[mGK]//g")
+output=$(echo "$output" | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2};?)?)?[mGK]//g")
 
-echo "changelog<<$DELIMITER" >>$GITHUB_OUTPUT
-echo "$OUTPUT" >>$GITHUB_OUTPUT
-echo "$DELIMITER" >>$GITHUB_OUTPUT
+echo "changelog<<$delimiter" >>$GITHUB_OUTPUT
+[ -n "$output" ] && echo "$output" >>$GITHUB_OUTPUT
+[ -z "$output" ] && echo "No changes in the OpenAPI spec" >>$GITHUB_OUTPUT
+echo "$delimiter" >>$GITHUB_OUTPUT
 
 echo '```' >>$GITHUB_STEP_SUMMARY
-echo "$OUTPUT" >>$GITHUB_STEP_SUMMARY
+[ -n "$output" ] && echo "$output" >>$GITHUB_STEP_SUMMARY
+[ -z "$output" ] && echo "No changes in the OpenAPI spec" >>$GITHUB_STEP_SUMMARY
 echo '```' >>$GITHUB_STEP_SUMMARY

--- a/changelog/entrypoint.sh
+++ b/changelog/entrypoint.sh
@@ -17,9 +17,9 @@ echo "flags: $flags"
 set -o pipefail
 
 if [ -n "$flags" ]; then
-    OUTPUT=$(oasdiff changelog "$base" "$revision" $flags)
+    OUTPUT=$(unbuffer oasdiff changelog "$base" "$revision" $flags)
 else
-    OUTPUT=$(oasdiff changelog "$base" "$revision")
+    OUTPUT=$(unbuffer oasdiff changelog "$base" "$revision")
 fi
 
 echo "$OUTPUT"
@@ -33,6 +33,9 @@ if [ "$SIZE" -ge "1000000" ]; then
 fi
 
 DELIMITER=$(cat /proc/sys/kernel/random/uuid | tr -d '-')
+
+# Remove ANSI color codes
+OUTPUT=$(echo "$OUTPUT" | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2};?)?)?[mGK]//g")
 
 echo "changelog<<$DELIMITER" >>$GITHUB_OUTPUT
 echo "$OUTPUT" >>$GITHUB_OUTPUT

--- a/changelog/entrypoint.sh
+++ b/changelog/entrypoint.sh
@@ -38,11 +38,17 @@ delimiter=$(cat /proc/sys/kernel/random/uuid | tr -d '-')
 output=$(echo "$output" | sed -r "s/\x1B\[([0-9]{1,3}(;[0-9]{1,2};?)?)?[mGK]//g")
 
 echo "changelog<<$delimiter" >>$GITHUB_OUTPUT
-[ -n "$output" ] && echo "$output" >>$GITHUB_OUTPUT
-[ -z "$output" ] && echo "No changes in the OpenAPI spec" >>$GITHUB_OUTPUT
+if [ -n "$output" ]; then
+    echo "$output" >>$GITHUB_OUTPUT
+else
+    echo "No changes in the OpenAPI spec" >>$GITHUB_OUTPUT
+fi
 echo "$delimiter" >>$GITHUB_OUTPUT
 
 echo '```' >>$GITHUB_STEP_SUMMARY
-[ -n "$output" ] && echo "$output" >>$GITHUB_STEP_SUMMARY
-[ -z "$output" ] && echo "No changes in the OpenAPI spec" >>$GITHUB_STEP_SUMMARY
+if [ -n "$output" ]; then
+    echo "$output" >>$GITHUB_STEP_SUMMARY
+else
+    echo "No changes in the OpenAPI spec" >>$GITHUB_STEP_SUMMARY
+fi
 echo '```' >>$GITHUB_STEP_SUMMARY

--- a/diff/action.yml
+++ b/diff/action.yml
@@ -19,6 +19,9 @@ inputs:
     description: 'Include path parameter names in endpoint matching'
     required: false
     default: 'false'
+outputs:
+  changelog:
+    description: 'Report of changes to the OpenAPI specification in the requested format (string encoded)'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/diff/entrypoint.sh
+++ b/diff/entrypoint.sh
@@ -43,7 +43,9 @@ fi
 delimiter=$(cat /proc/sys/kernel/random/uuid | tr -d '-')
 
 echo "diff<<$delimiter" >>$GITHUB_OUTPUT
-[ -n "$output" ] && echo "$output" >>$GITHUB_OUTPUT
+if [ -n "$output" ]; then
+    echo "$output" >>$GITHUB_OUTPUT
+fi
 echo "$delimiter" >>$GITHUB_OUTPUT
 
 if [ "$format" = "text" && -n "$output" ]; then

--- a/diff/entrypoint.sh
+++ b/diff/entrypoint.sh
@@ -25,27 +25,27 @@ echo "flags: $flags"
 set -o pipefail
 
 if [ -n "$flags" ]; then
-    OUTPUT=$(oasdiff diff "$base" "$revision" $flags)
+    output=$(oasdiff diff "$base" "$revision" $flags)
 else
-    OUTPUT=$(oasdiff diff "$base" "$revision")
+    output=$(oasdiff diff "$base" "$revision")
 fi
 
-echo "$OUTPUT"
+echo "$output"
 
 # GitHub Actions limits output to 1MB
 # We count bytes because unicode has multibyte characters
-SIZE=$(echo "$OUTPUT" | wc -c)
-if [ "$SIZE" -ge "1000000" ]; then
+size=$(echo "$output" | wc -c)
+if [ "$size" -ge "1000000" ]; then
     echo "WARN: Diff exceeds the 1MB limit, truncating output..." >&2
-    OUTPUT=$(echo "$OUTPUT" | head -c $LIMIT)
+    output=$(echo "$output" | head -c $1000000)
 fi
 
-DELIMITER=$(cat /proc/sys/kernel/random/uuid | tr -d '-')
+delimiter=$(cat /proc/sys/kernel/random/uuid | tr -d '-')
 
-echo "diff<<$DELIMITER" >>$GITHUB_OUTPUT
-echo "$OUTPUT" >>$GITHUB_OUTPUT
-echo "$DELIMITER" >>$GITHUB_OUTPUT
+echo "diff<<$delimiter" >>$GITHUB_OUTPUT
+[ -n "$output" ] && echo "$output" >>$GITHUB_OUTPUT
+echo "$delimiter" >>$GITHUB_OUTPUT
 
-if [ "$format" = "text" ]; then
-    echo "$OUTPUT" >>$GITHUB_STEP_SUMMARY
+if [ "$format" = "text" && -n "$output" ]; then
+    echo "$output" >>$GITHUB_STEP_SUMMARY
 fi


### PR DESCRIPTION
Output to GitHub and share in the job summary if the format is markdown-compatible

Closes #15 