### PR TITLE
Add --deprecation-days-XXX flag for breaking-action

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,7 +39,6 @@ jobs:
         run: |
           # Deprecate Beta in 14 days
           sed -ie "s/{{SUNSET_DATE_BETA}}/$(date --date="14 day" "+%Y-%m-%d")/" specs/base-deprecation.yaml
-          2kwnFPhViCLjoc6CoB
           # Deprecate Stable in 21 days
           sed -ie "s/{{SUNSET_DATE_STABLE}}/$(date --date="21 day" "+%Y-%m-%d")/" specs/base-deprecation.yaml
       - name: Running OpenAPI Spec check breaking action

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,6 +29,31 @@ jobs:
           base: https://raw.githubusercontent.com/Tufin/oasdiff/main/data/openapi-test1.yaml
           revision: https://raw.githubusercontent.com/Tufin/oasdiff/main/data/openapi-test3.yaml
           fail-on-diff: false
+  oas_diff_breaking_deprecations_job:
+    runs-on: ubuntu-latest
+    name: A job to test OpenAPI Spec breaking deprecations
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: Create deprecated specs
+        run: |
+          cp specs/base.yaml specs/deprecated.yaml
+          # Deprecate Beta in 14 days
+          sed -i "/operationId: listPets/s/$/\n      deprecated: true/" specs/deprecated.yaml
+          sed -i "/operationId: listPets/s/$/\n      x-stability-level: beta/" specs/deprecated.yaml
+          sed -i "/operationId: listPets/s/$/\n      x-sunset: $(date --date="14 day" "+%Y-%m-%d")/" specs/deprecated.yaml
+          # Deprecate Stable in 21 days
+          sed -i "/operationId: createPets/s/$/\n      deprecated: true/" specs/deprecated.yaml
+          sed -i "/operationId: createPets/s/$/\n      x-sunset: $(date --date="21 day" "+%Y-%m-%d")/" specs/deprecated.yaml
+      - name: Running OpenAPI Spec check breaking action
+        id: test_breaking_deprecations
+        uses: ./breaking
+        with:
+          base: specs/base.yaml
+          revision: specs/deprecated.yaml
+          fail-on-diff: true
+          deprecation-days-beta: 14
+          deprecation-days-stable: 21
   oas_diff_changelog_tag_job:
     runs-on: ubuntu-latest
     name: A job to test tag release of OpenAPI Spec changelog action

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,22 +35,19 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v3
-      - name: Create deprecated specs
+      - name: Set date for deprecated specs
         run: |
-          cp specs/base.yaml specs/deprecated.yaml
           # Deprecate Beta in 14 days
-          sed -i "/operationId: listPets/s/$/\n      deprecated: true/" specs/deprecated.yaml
-          sed -i "/operationId: listPets/s/$/\n      x-stability-level: beta/" specs/deprecated.yaml
-          sed -i "/operationId: listPets/s/$/\n      x-sunset: $(date --date="14 day" "+%Y-%m-%d")/" specs/deprecated.yaml
+          sed -ie "s/{{SUNSET_DATE_BETA}}/$(date --date="14 day" "+%Y-%m-%d")/" specs/base-deprecation.yaml
+          2kwnFPhViCLjoc6CoB
           # Deprecate Stable in 21 days
-          sed -i "/operationId: createPets/s/$/\n      deprecated: true/" specs/deprecated.yaml
-          sed -i "/operationId: createPets/s/$/\n      x-sunset: $(date --date="21 day" "+%Y-%m-%d")/" specs/deprecated.yaml
+          sed -ie "s/{{SUNSET_DATE_STABLE}}/$(date --date="21 day" "+%Y-%m-%d")/" specs/base-deprecation.yaml
       - name: Running OpenAPI Spec check breaking action
         id: test_breaking_deprecations
         uses: ./breaking
         with:
           base: specs/base.yaml
-          revision: specs/deprecated.yaml
+          revision: specs/base-deprecation.yaml
           fail-on-diff: true
           deprecation-days-beta: 14
           deprecation-days-stable: 21

--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ Copy and paste the following snippet into your build .yml file:
 
 Additional arguments:
 
-| CLI                   | Action input            | Default |
-|-----------------------|-------------------------|---------|
-| --fail-on WARN        | fail-on-diff            | true    |
-| --include-checks      | include-checks          | csv     |
-| --include-path-params | include-path-params     | false   |
-| --deprecation-days-beta | deprecation-days-beta   | 31      |
+| CLI                       | Action input            | Default |
+|---------------------------|-------------------------|---------|
+| --fail-on WARN            | fail-on-diff            | true    |
+| --include-checks          | include-checks          | csv     |
+| --include-path-params     | include-path-params     | false   |
+| --deprecation-days-beta   | deprecation-days-beta   | 31      |
 | --deprecation-days-stable | deprecation-days-stable | 180     |
 
 

--- a/README.md
+++ b/README.md
@@ -36,11 +36,13 @@ Copy and paste the following snippet into your build .yml file:
 
 Additional arguments:
 
-| CLI                   | Action input | Default |
-|-----------------------|--------|--------|
-| --fail-on WARN        | fail-on-diff | true |
-| --include-checks      | include-checks | csv |
-| --include-path-params | include-path-params | false |
+| CLI                   | Action input            | Default |
+|-----------------------|-------------------------|---------|
+| --fail-on WARN        | fail-on-diff            | true    |
+| --include-checks      | include-checks          | csv     |
+| --include-path-params | include-path-params     | false   |
+| --deprecation-days-beta | deprecation-days-beta   | 31      |
+| --deprecation-days-stable | deprecation-days-stable | 180     |
 
 
 ### Generate a changelog

--- a/breaking/action.yml
+++ b/breaking/action.yml
@@ -21,11 +21,9 @@ inputs:
   deprecation-days-beta:
     description: 'Consider minimum sunset period for deprecation of beta API endpoints'
     required: false
-    default: '31'
   deprecation-days-stable:
     description: 'Consider minimum sunset period for deprecation of stable API endpoints'
     required: false
-    default: '180'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/breaking/action.yml
+++ b/breaking/action.yml
@@ -18,6 +18,14 @@ inputs:
     description: 'Include path parameter names in endpoint matching'
     required: false
     default: 'false'
+  deprecation-days-beta:
+    description: 'Consider minimum sunset period for deprecation of beta API endpoints'
+    required: false
+    default: '31'
+  deprecation-days-stable:
+    description: 'Consider minimum sunset period for deprecation of stable API endpoints'
+    required: false
+    default: '180'
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -27,3 +35,5 @@ runs:
     - ${{ inputs.fail-on-diff }}
     - ${{ inputs.include-checks }}
     - ${{ inputs.include-path-params }}
+    - ${{ inputs.deprecation-days-beta }}
+    - ${{ inputs.deprecation-days-stable }}

--- a/breaking/entrypoint.sh
+++ b/breaking/entrypoint.sh
@@ -6,8 +6,10 @@ readonly revision="$2"
 readonly fail_on_diff="$3" 
 readonly include_checks="$4"
 readonly include_path_params="$5"
+readonly deprecation_days_beta="$6"
+readonly deprecation_days_stable="$7"
 
-echo "running oasdiff breaking base: $base, revision: $revision, fail_on_diff: $fail_on_diff, include_checks: $include_checks, include_path_params: $include_path_params"
+echo "running oasdiff breaking base: $base, revision: $revision, fail_on_diff: $fail_on_diff, include_checks: $include_checks, include_path_params: $include_path_params, deprecation_days_beta: $deprecation_days_beta, deprecation_days_stable: $deprecation_days_stable"
 
 # Build flags to pass in command
 flags=""
@@ -19,6 +21,12 @@ if [ "$include_path_params" = "true" ]; then
 fi
 if [ -n "$include_checks" ]; then
     flags="${flags} --include-checks $include_checks"
+fi
+if [ -n "$deprecation_days_beta" ]; then
+    flags="${flags} --deprecation-days-beta $deprecation_days_beta"
+fi
+if [ -n "$deprecation_days_stable" ]; then
+    flags="${flags} --deprecation-days-stable $deprecation_days_stable"
 fi
 echo "flags: $flags"
 

--- a/specs/base-deprecation.yaml
+++ b/specs/base-deprecation.yaml
@@ -1,0 +1,116 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      deprecated: true
+      x-stability-level: beta
+      x-sunset: {{SUNSET_DATE_BETA}}
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: A paged array of pets
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      summary: Create a pet
+      operationId: createPets
+      deprecated: true
+      x-sunset: {{SUNSET_DATE_STABLE}}
+      tags:
+        - pets
+      responses:
+        '201':
+          description: Null response
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /pets/{petId}:
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+    Pets:
+      type: array
+      items:
+        $ref: "#/components/schemas/Pet"
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string


### PR DESCRIPTION
Hey everyone! 

Right now it is not possible to change the default parameters for the sunsetting periods for deprecation of beta and stable endpoints. This PR adds those parameters and takes over explicitly the default parameters used in oasdiff.

Would be great to have this capability and I am happy to change the PR if anything is missing!