### PR TITLE
GitHub Action Output Part 3: github-action limits output to 1MB

### DIFF
--- a/breaking/entrypoint.sh
+++ b/breaking/entrypoint.sh
@@ -45,7 +45,15 @@ if [ -n "$flags" ]; then
 else
     output=$(oasdiff breaking "$base" "$revision" | head -n 1)
 fi
+
 if [ -n "$output" ]; then
+    # github-action limits output to 1MB
+    # we count bytes because unicode has multibyte characters
+    size=$(echo "$output" | wc -c)
+    if [ "$size" -ge "1000000" ]; then
+        echo "WARN: breaking exceeds the 1MB limit, truncating output..." >&2
+        output=$(echo "$output" | head -c $1000000)
+    fi
     echo "$output" >>$GITHUB_OUTPUT
 else
     echo "No breaking changes" >>$GITHUB_OUTPUT


### PR DESCRIPTION
This PR is part 2 of https://github.com/oasdiff/oasdiff-action/pull/18 created by @tuxmachine