### PR TITLE
fix: report schema errors

### DIFF
--- a/breaking/entrypoint.sh
+++ b/breaking/entrypoint.sh
@@ -36,6 +36,11 @@ echo "flags: $flags"
 
 # *** github action step output ***
 
+# Writes the summary to log and updates GitHub Action summary
+oasdiff breaking "$base" "$revision" $flags --format githubactions
+
+# *** github action step output ***
+
 # output name should be in the syntax of multiple lines:
 # {name}<<{delimiter}
 # {value}
@@ -64,10 +69,3 @@ else
 fi
 
 echo "$delimiter" >>$GITHUB_OUTPUT
-
-# *** github action step output ***
-
-# Updating GitHub Action summary with formatted output
-flags="${flags} --format githubactions"
-# Writes the summary to log and updates GitHub Action summary
-oasdiff breaking "$base" "$revision" $flags

--- a/changelog/entrypoint.sh
+++ b/changelog/entrypoint.sh
@@ -30,10 +30,17 @@ set -o pipefail
 delimiter=$(cat /proc/sys/kernel/random/uuid | tr -d '-')
 echo "changelog<<$delimiter" >>$GITHUB_OUTPUT
 
+set +e
 if [ -n "$flags" ]; then
-    output=$(oasdiff changelog "$base" "$revision" $flags)
+    output=$(oasdiff changelog "$base" "$revision" $flags 2>&1)
 else
-    output=$(oasdiff changelog "$base" "$revision")
+    output=$(oasdiff changelog "$base" "$revision" 2>&1)
+fi
+set -e
+
+if [[ "$output" == Error* ]]; then
+    echo "$output"
+    exit 1
 fi
 
 if [ -n "$output" ]; then

--- a/diff/entrypoint.sh
+++ b/diff/entrypoint.sh
@@ -38,10 +38,17 @@ echo "diff<<$delimiter" >>$GITHUB_OUTPUT
 
 set -o pipefail
 
+set +e
 if [ -n "$flags" ]; then
-    output=$(oasdiff diff "$base" "$revision" $flags)
+    output=$(oasdiff diff "$base" "$revision" $flags 2>&1)
 else
-    output=$(oasdiff diff "$base" "$revision")
+    output=$(oasdiff diff "$base" "$revision" 2>&1)
+fi
+set -e
+
+if [[ "$output" == Error* ]]; then
+    echo "$output"
+    exit 1
 fi
 
 if [ -n "$output" ]; then


### PR DESCRIPTION
Otherwise the action fails silently when there's an errors in the OpenAPI spec.

I've tested this on our own fork that uses a tweaked version of the `breaking` action, but it should probably be tested a bit further by people that use the other actions. 