### PR TITLE
Include changelog output in action definition.

### DIFF
--- a/changelog/action.yml
+++ b/changelog/action.yml
@@ -15,6 +15,9 @@ inputs:
     description: 'Exclude certain kinds of changes'
     required: false
     default: ''
+outputs:
+  changelog:
+    description: 'Output summary of API changelog'
 runs:
   using: 'docker'
   image: 'Dockerfile'


### PR DESCRIPTION
### Change summary

Include the changelog outputs in the action definition. They are missing from this command.