### PR TITLE
Add output to file option

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -73,3 +73,11 @@ jobs:
         with:
           base: https://raw.githubusercontent.com/Tufin/oasdiff/main/data/openapi-test1.yaml
           revision: https://raw.githubusercontent.com/Tufin/oasdiff/main/data/openapi-test3.yaml
+      - name: Test changelog action output
+        run: |
+          readonly expected_output="20 changes: 2 error, 4 warning, 14 info"
+          output=$(echo "${{steps.test_changelog.outputs.changelog}}" | head -n 1)
+          if [[  "${output}" != "${expected_output}" ]]; then
+            echo "Expected output '20 changes: 2 error, 4 warning, 14 info' but got '${output}'" >&2
+            exit 1
+          fi  

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,6 +16,31 @@ jobs:
             base: https://raw.githubusercontent.com/Tufin/oasdiff/main/data/openapi-test1.yaml
             revision: https://raw.githubusercontent.com/Tufin/oasdiff/main/data/openapi-test3.yaml
             format: 'text'
+  oasdiff_diff_exclude_elements:
+    runs-on: ubuntu-latest
+    name: Test diff action with exclude-elements option
+    steps:
+        - name: checkout
+          uses: actions/checkout@v3
+        - name: Running diff action with exclude-elements option
+          id: test_exclude_elements
+          uses: ./diff
+          with:
+            base: 'specs/base.yaml'
+            revision: 'specs/base-exclude-elements.yaml'
+            format: 'text'
+            exclude-elements: 'description,title,summary'
+        - name: Test diff action output
+          run: |
+            delimiter=$(cat /proc/sys/kernel/random/uuid | tr -d '-')
+            output=$(cat <<-$delimiter
+            ${{ steps.test_exclude_elements.outputs.diff }}
+            $delimiter
+            )
+            if [ "$output" != "No changes" ]; then
+              echo "Expected output 'No changes' but got '$output'" >&2
+              exit 1
+            fi
   oasdiff_breaking:
     runs-on: ubuntu-latest
     name: Test breaking changes

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ jobs:
     name: Test diff action
     steps:
         - name: checkout
-          uses: actions/checkout@v3
+          uses: actions/checkout@v4
         - name: Running diff action
           id: test_ete
           uses: ./diff
@@ -21,7 +21,7 @@ jobs:
     name: Test diff action with exclude-elements option
     steps:
         - name: checkout
-          uses: actions/checkout@v3
+          uses: actions/checkout@v4
         - name: Running diff action with exclude-elements option
           id: test_exclude_elements
           uses: ./diff
@@ -46,7 +46,7 @@ jobs:
     name: Test breaking changes
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Running breaking action
         id: test_breaking_changes
         uses: ./breaking
@@ -70,7 +70,7 @@ jobs:
     name: Test breaking changes with deprecation
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set date for deprecated specs
         run: |
           # Deprecate Beta in 14 days
@@ -91,7 +91,7 @@ jobs:
     name: Test generation of changelog
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Running changelog action
         id: test_changelog
         uses: ./changelog

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,15 +7,22 @@ jobs:
     runs-on: ubuntu-latest
     name: Test diff action
     steps:
-        - name: checkout
-          uses: actions/checkout@v4
-        - name: Running diff action
-          id: test_ete
-          uses: ./diff
-          with:
-            base: https://raw.githubusercontent.com/Tufin/oasdiff/main/data/openapi-test1.yaml
-            revision: https://raw.githubusercontent.com/Tufin/oasdiff/main/data/openapi-test3.yaml
-            format: 'text'
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: Running diff action
+        id: test_ete
+        uses: ./diff
+        with:
+          base: https://raw.githubusercontent.com/Tufin/oasdiff/main/data/openapi-test1.yaml
+          revision: https://raw.githubusercontent.com/Tufin/oasdiff/main/data/openapi-test3.yaml
+          format: 'text'
+          output-to-file: 'diff.txt'
+      - name: Test diff action output to file
+        run: |
+          if [ ! -s diff.txt ]; then
+            echo "Diff file doesn't exist or is empty"
+            exit 1
+          fi
   oasdiff_diff_exclude_elements:
     runs-on: ubuntu-latest
     name: Test diff action with exclude-elements option
@@ -54,6 +61,7 @@ jobs:
           base: 'specs/base.yaml'
           revision: 'specs/revision-breaking.yaml'
           fail-on-diff: false
+          output-to-file: 'breaking.txt'
       - name: Test breaking changes action output
         run: |
           delimiter=$(cat /proc/sys/kernel/random/uuid | tr -d '-')
@@ -62,7 +70,18 @@ jobs:
           $delimiter
           )
           if [ "$output" != "1 breaking changes: 1 error, 0 warning" ]; then
-            echo "Expected output '6 breaking changes: 2 error, 4 warning' but got '$output'" >&2
+            echo "Expected output '1 breaking changes: 1 error, 0 warning' but got '$output'" >&2
+            exit 1
+          fi
+      - name: Test breaking changes action output to file
+        run: |
+          if [ ! -s breaking.txt ]; then
+            echo "Breaking changes file doesn't exist or is empty"
+            exit 1
+          fi
+          output=$(cat breaking.txt)
+          if [[  "${output}" != "1 breaking changes: 1 error, 0 warning" ]]; then
+            echo "Expected output '1 breaking changes: 1 error, 0 warning' but got '${output}'" >&2
             exit 1
           fi
   oasdiff_breaking_deprecation:
@@ -98,6 +117,7 @@ jobs:
         with:
           base: https://raw.githubusercontent.com/Tufin/oasdiff/main/data/openapi-test1.yaml
           revision: https://raw.githubusercontent.com/Tufin/oasdiff/main/data/openapi-test3.yaml
+          output-to-file: "changelog.txt"
       - name: Test changelog action output
         run: |
           readonly expected_output="20 changes: 2 error, 4 warning, 14 info"
@@ -105,4 +125,15 @@ jobs:
           if [[  "${output}" != "${expected_output}" ]]; then
             echo "Expected output '20 changes: 2 error, 4 warning, 14 info' but got '${output}'" >&2
             exit 1
-          fi  
+          fi
+      - name: Test changelog action output to file
+        run: |
+          if [ ! -s changelog.txt ]; then
+            echo "Changelog file doesn't exist or is empty"
+            exit 1
+          fi
+          output=$(cat changelog.txt | head -n 1)
+          if [[  "${output}" != "20 changes: 2 error, 4 warning, 14 info" ]]; then
+            echo "Expected output '20 changes: 2 error, 4 warning, 14 info' but got '${output}'" >&2
+            exit 1
+          fi

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -104,7 +104,7 @@ jobs:
             echo "Breaking changes file doesn't exist or is empty"
             exit 1
           fi
-          output=$(cat breaking.txt)
+          output=$(cat breaking.txt | head -n 1)
           if [[  "${output}" != "1 breaking changes: 1 error, 0 warning" ]]; then
             echo "Expected output '1 breaking changes: 1 error, 0 warning' but got '${output}'" >&2
             exit 1

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This action supports additional arguments that are converted to parameters for t
 | --fail-on-diff | fail-on-diff | false |
 | --format | format | yaml |
 | --include-path-params | include-path-params | false |
+| --exclude-elements | exclude-elements | '' |
 
 ### Check for breaking API changes, and fail if any are found
 Copy and paste the following snippet into your build .yml file:
@@ -43,6 +44,7 @@ Additional arguments:
 | --include-path-params     | include-path-params     | false   |
 | --deprecation-days-beta   | deprecation-days-beta   | 31      |
 | --deprecation-days-stable | deprecation-days-stable | 180     |
+| --exclude-elements        | exclude-elements        | ''      |
 
 This action delivers a summary of breaking changes, accessible as a GitHub step output named `breaking`.
 
@@ -61,3 +63,4 @@ Additional arguments:
 | CLI | Action input | Default |
 |--------|--------|--------|
 | --include-path-params | include-path-params | false |
+| --exclude-elements    | exclude-elements    | ''    |

--- a/README.md
+++ b/README.md
@@ -16,14 +16,15 @@ Copy and paste the following snippet into your build .yml file:
     revision: 'specs/revision.yaml'
 ```
 
-This action supports additional arguments that are converted to parameters for the `oasdiff` CLI.
+This action supports additional arguments. Most are converted to parameters for the `oasdiff` CLI.
 
-| CLI | Action input | Default |
-|--------|--------|--------|
-| --fail-on-diff | fail-on-diff | false |
-| --format | format | yaml |
-| --include-path-params | include-path-params | false |
-| --exclude-elements | exclude-elements | '' |
+| CLI                   | Action input        | Default |
+| --------------------- | ------------------- | ------- |
+| --fail-on-diff        | fail-on-diff        | false   |
+| --format              | format              | yaml    |
+| --include-path-params | include-path-params | false   |
+| --exclude-elements    | exclude-elements    | ''      |
+| N/A                   | output-to-file      | ''      |
 
 ### Check for breaking API changes, and fail if any are found
 Copy and paste the following snippet into your build .yml file:
@@ -38,13 +39,14 @@ Copy and paste the following snippet into your build .yml file:
 Additional arguments:
 
 | CLI                       | Action input            | Default |
-|---------------------------|-------------------------|---------|
+| ------------------------- | ----------------------- | ------- |
 | --fail-on WARN            | fail-on-diff            | true    |
 | --include-checks          | include-checks          | csv     |
 | --include-path-params     | include-path-params     | false   |
 | --deprecation-days-beta   | deprecation-days-beta   | 31      |
 | --deprecation-days-stable | deprecation-days-stable | 180     |
 | --exclude-elements        | exclude-elements        | ''      |
+| N/A                       | output-to-file          | ''      |
 
 This action delivers a summary of breaking changes, accessible as a GitHub step output named `breaking`.
 
@@ -60,7 +62,8 @@ Copy and paste the following snippet into your build .yml file:
 
 Additional arguments:
 
-| CLI | Action input | Default |
-|--------|--------|--------|
-| --include-path-params | include-path-params | false |
-| --exclude-elements    | exclude-elements    | ''    |
+| CLI                   | Action input        | Default |
+| --------------------- | ------------------- | ------- |
+| --include-path-params | include-path-params | false   |
+| --exclude-elements    | exclude-elements    | ''      |
+| N/A                   | output-to-file      | ''      |

--- a/breaking/action.yml
+++ b/breaking/action.yml
@@ -24,6 +24,10 @@ inputs:
   deprecation-days-stable:
     description: 'Consider minimum sunset period for deprecation of stable API endpoints'
     required: false
+  exclude-elements:
+    description: 'Exclude certain kinds of changes'
+    required: false
+    default: ''
 outputs:
   breaking:
     description: 'Output summary of API breaking changes, encompassing both warnings and errors'
@@ -38,3 +42,4 @@ runs:
     - ${{ inputs.include-path-params }}
     - ${{ inputs.deprecation-days-beta }}
     - ${{ inputs.deprecation-days-stable }}
+    - ${{ inputs.exclude-elements }}

--- a/breaking/action.yml
+++ b/breaking/action.yml
@@ -28,6 +28,10 @@ inputs:
     description: 'Exclude certain kinds of changes'
     required: false
     default: ''
+  output-to-file:
+    description: 'Output to a file at the given path'
+    required: false
+    default: ''
 outputs:
   breaking:
     description: 'Output summary of API breaking changes, encompassing both warnings and errors'
@@ -43,3 +47,4 @@ runs:
     - ${{ inputs.deprecation-days-beta }}
     - ${{ inputs.deprecation-days-stable }}
     - ${{ inputs.exclude-elements }}
+    - ${{ inputs.output-to-file }}

--- a/breaking/entrypoint.sh
+++ b/breaking/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -e
 
+source $GITHUB_WORKSPACE/common/common.sh
+
 readonly base="$1"
 readonly revision="$2"
 readonly fail_on_diff="$3"
@@ -9,28 +11,29 @@ readonly include_path_params="$5"
 readonly deprecation_days_beta="$6"
 readonly deprecation_days_stable="$7"
 readonly exclude_elements="$8"
+readonly output_to_file="$9"
 
 echo "running oasdiff breaking... base: $base, revision: $revision, fail_on_diff: $fail_on_diff, include_checks: $include_checks, include_path_params: $include_path_params, deprecation_days_beta: $deprecation_days_beta, deprecation_days_stable: $deprecation_days_stable, exclude_elements: $exclude_elements"
 
 # Build flags to pass in command
 flags=""
 if [ "$fail_on_diff" = "true" ]; then
-    flags="${flags} --fail-on WARN"
+    flags="$flags --fail-on WARN"
 fi
 if [ "$include_path_params" = "true" ]; then
-    flags="${flags} --include-path-params"
+    flags="$flags --include-path-params"
 fi
 if [ -n "$include_checks" ]; then
-    flags="${flags} --include-checks $include_checks"
+    flags="$flags --include-checks $include_checks"
 fi
 if [ -n "$deprecation_days_beta" ]; then
-    flags="${flags} --deprecation-days-beta $deprecation_days_beta"
+    flags="$flags --deprecation-days-beta $deprecation_days_beta"
 fi
 if [ -n "$deprecation_days_stable" ]; then
-    flags="${flags} --deprecation-days-stable $deprecation_days_stable"
+    flags="$flags --deprecation-days-stable $deprecation_days_stable"
 fi
-if [ "$exclude_elements" != "" ]; then
-    flags="${flags} --exclude-elements ${exclude_elements}"
+if [ -n "$exclude_elements" ]; then
+    flags="$flags --exclude-elements $exclude_elements"
 fi
 echo "flags: $flags"
 
@@ -42,7 +45,7 @@ echo "flags: $flags"
 # {delimiter}
 # see: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
 delimiter=$(cat /proc/sys/kernel/random/uuid | tr -d '-')
-echo "breaking<<$delimiter" >>$GITHUB_OUTPUT
+echo "breaking<<$delimiter" >>"$GITHUB_OUTPUT"
 
 if [ -n "$flags" ]; then
     output=$(oasdiff breaking "$base" "$revision" $flags | head -n 1)
@@ -51,23 +54,16 @@ else
 fi
 
 if [ -n "$output" ]; then
-    # github-action limits output to 1MB
-    # we count bytes because unicode has multibyte characters
-    size=$(echo "$output" | wc -c)
-    if [ "$size" -ge "1000000" ]; then
-        echo "WARN: breaking exceeds the 1MB limit, truncating output..." >&2
-        output=$(echo "$output" | head -c 1000000)
-    fi
-    echo "$output" >>$GITHUB_OUTPUT
+    write_output "$output"
 else
-    echo "No breaking changes" >>$GITHUB_OUTPUT
+    write_output "No breaking changes"
 fi
 
-echo "$delimiter" >>$GITHUB_OUTPUT
+echo "$delimiter" >>"$GITHUB_OUTPUT"
 
 # *** github action step output ***
 
 # Updating GitHub Action summary with formatted output
-flags="${flags} --format githubactions"
+flags="$flags --format githubactions"
 # Writes the summary to log and updates GitHub Action summary
 oasdiff breaking "$base" "$revision" $flags

--- a/breaking/entrypoint.sh
+++ b/breaking/entrypoint.sh
@@ -52,13 +52,13 @@ delimiter=$(cat /proc/sys/kernel/random/uuid | tr -d '-')
 echo "breaking<<$delimiter" >>"$GITHUB_OUTPUT"
 
 if [ -n "$flags" ]; then
-    output=$(oasdiff breaking "$base" "$revision" $flags | head -n 1)
+    output=$(oasdiff breaking "$base" "$revision" $flags)
 else
-    output=$(oasdiff breaking "$base" "$revision" | head -n 1)
+    output=$(oasdiff breaking "$base" "$revision")
 fi
 
 if [ -n "$output" ]; then
-    write_output "$output"
+    write_output "$(head -n 1 <<< "$output")" "$output"
 else
     write_output "No breaking changes"
 fi

--- a/breaking/entrypoint.sh
+++ b/breaking/entrypoint.sh
@@ -14,7 +14,7 @@ readonly exclude_elements="$8"
 readonly composed="$9"
 readonly output_to_file="${10}"
 
-echo "running oasdiff breaking... base: $base, revision: $revision, fail_on_diff: $fail_on_diff, include_checks: $include_checks, include_path_params: $include_path_params, deprecation_days_beta: $deprecation_days_beta, deprecation_days_stable: $deprecation_days_stable, exclude_elements: $exclude_elements"
+echo "running oasdiff breaking... base: $base, revision: $revision, fail_on_diff: $fail_on_diff, include_checks: $include_checks, include_path_params: $include_path_params, deprecation_days_beta: $deprecation_days_beta, deprecation_days_stable: $deprecation_days_stable, exclude_elements: $exclude_elements, composed: $composed, output_to_file: $output_to_file"
 
 # Build flags to pass in command
 flags=""
@@ -58,7 +58,7 @@ else
 fi
 
 if [ -n "$output" ]; then
-    write_output "$(head -n 1 <<< "$output")" "$output"
+    write_output "$(echo "$output" | head -n 1)" "$output"
 else
     write_output "No breaking changes"
 fi

--- a/breaking/entrypoint.sh
+++ b/breaking/entrypoint.sh
@@ -8,8 +8,9 @@ readonly include_checks="$4"
 readonly include_path_params="$5"
 readonly deprecation_days_beta="$6"
 readonly deprecation_days_stable="$7"
+readonly exclude_elements="$8"
 
-echo "running oasdiff breaking... base: $base, revision: $revision, fail_on_diff: $fail_on_diff, include_checks: $include_checks, include_path_params: $include_path_params, deprecation_days_beta: $deprecation_days_beta, deprecation_days_stable: $deprecation_days_stable"
+echo "running oasdiff breaking... base: $base, revision: $revision, fail_on_diff: $fail_on_diff, include_checks: $include_checks, include_path_params: $include_path_params, deprecation_days_beta: $deprecation_days_beta, deprecation_days_stable: $deprecation_days_stable, exclude_elements: $exclude_elements"
 
 # Build flags to pass in command
 flags=""
@@ -27,6 +28,9 @@ if [ -n "$deprecation_days_beta" ]; then
 fi
 if [ -n "$deprecation_days_stable" ]; then
     flags="${flags} --deprecation-days-stable $deprecation_days_stable"
+fi
+if [ "$exclude_elements" != "" ]; then
+    flags="${flags} --exclude-elements ${exclude_elements}"
 fi
 echo "flags: $flags"
 

--- a/changelog/action.yml
+++ b/changelog/action.yml
@@ -15,6 +15,9 @@ inputs:
     description: 'Exclude certain kinds of changes'
     required: false
     default: ''
+outputs:
+  changelog:
+    description: 'Output summary of API changelog'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/changelog/action.yml
+++ b/changelog/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: 'Exclude certain kinds of changes'
     required: false
     default: ''
+  output-to-file:
+    description: 'Output to a file at the given path'
+    required: false
+    default: ''
 outputs:
   changelog:
     description: 'Output summary of API changelog'
@@ -26,3 +30,4 @@ runs:
     - ${{ inputs.revision }}
     - ${{ inputs.include-path-params }}
     - ${{ inputs.exclude-elements }}
+    - ${{ inputs.output-to-file }}

--- a/changelog/action.yml
+++ b/changelog/action.yml
@@ -11,6 +11,10 @@ inputs:
     description: 'Include path parameter names in endpoint matching'
     required: false
     default: 'false'
+  exclude-elements:
+    description: 'Exclude certain kinds of changes'
+    required: false
+    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -18,3 +22,4 @@ runs:
     - ${{ inputs.base }}
     - ${{ inputs.revision }}
     - ${{ inputs.include-path-params }}
+    - ${{ inputs.exclude-elements }}

--- a/changelog/entrypoint.sh
+++ b/changelog/entrypoint.sh
@@ -4,13 +4,17 @@ set -e
 readonly base="$1"
 readonly revision="$2"
 readonly include_path_params="$3"
+readonly exclude_elements="$4"
 
-echo "running oasdiff changelog base: $base, revision: $revision, include_path_params: $include_path_params"
+echo "running oasdiff changelog base: $base, revision: $revision, include_path_params: $include_path_params, exclude_elements: $exclude_elements"
 
 # Build flags to pass in command
 flags=""
 if [ "$include_path_params" = "true" ]; then
     flags="${flags} --include-path-params"
+fi
+if [ "$exclude_elements" != "" ]; then
+    flags="${flags} --exclude-elements ${exclude_elements}"
 fi
 echo "flags: $flags"
 

--- a/changelog/entrypoint.sh
+++ b/changelog/entrypoint.sh
@@ -10,7 +10,7 @@ readonly exclude_elements="$4"
 readonly composed="$5"
 readonly output_to_file="$6"
 
-echo "running oasdiff changelog base: $base, revision: $revision, include_path_params: $include_path_params, exclude_elements: $exclude_elements"
+echo "running oasdiff changelog base: $base, revision: $revision, include_path_params: $include_path_params, exclude_elements: $exclude_elements, composed: $composed, output_to_file: $output_to_file"
 
 # Build flags to pass in command
 flags=""

--- a/changelog/entrypoint.sh
+++ b/changelog/entrypoint.sh
@@ -1,20 +1,23 @@
 #!/bin/sh
 set -e
 
+source $GITHUB_WORKSPACE/common/common.sh
+
 readonly base="$1"
 readonly revision="$2"
 readonly include_path_params="$3"
 readonly exclude_elements="$4"
+readonly output_to_file="$5"
 
 echo "running oasdiff changelog base: $base, revision: $revision, include_path_params: $include_path_params, exclude_elements: $exclude_elements"
 
 # Build flags to pass in command
 flags=""
 if [ "$include_path_params" = "true" ]; then
-    flags="${flags} --include-path-params"
+    flags="$flags --include-path-params"
 fi
-if [ "$exclude_elements" != "" ]; then
-    flags="${flags} --exclude-elements ${exclude_elements}"
+if [ -n "$exclude_elements" ]; then
+    flags="$flags --exclude-elements $exclude_elements"
 fi
 echo "flags: $flags"
 
@@ -28,7 +31,7 @@ set -o pipefail
 # {delimiter}
 # see: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
 delimiter=$(cat /proc/sys/kernel/random/uuid | tr -d '-')
-echo "changelog<<$delimiter" >>$GITHUB_OUTPUT
+echo "changelog<<$delimiter" >>"$GITHUB_OUTPUT"
 
 if [ -n "$flags" ]; then
     output=$(oasdiff changelog "$base" "$revision" $flags)
@@ -37,19 +40,12 @@ else
 fi
 
 if [ -n "$output" ]; then
-    # github-action limits output to 1MB
-    # we count bytes because unicode has multibyte characters
-    size=$(echo "$output" | wc -c)
-    if [ "$size" -ge "1000000" ]; then
-        echo "WARN: changelog exceeds the 1MB limit, truncating output..." >&2
-        output=$(echo "$output" | head -c 1000000)
-    fi
-    echo "$output" >>$GITHUB_OUTPUT
+    write_output "$output"
 else
-    echo "No changelog changes" >>$GITHUB_OUTPUT
+    write_output "No changelog changes"
 fi
 
-echo "$delimiter" >>$GITHUB_OUTPUT
+echo "$delimiter" >>"$GITHUB_OUTPUT"
 
 # *** github action step output ***
 

--- a/common/common.sh
+++ b/common/common.sh
@@ -1,0 +1,14 @@
+write_output () {
+    local output="$1"
+    if [ -n "$output_to_file" ]; then
+        echo "$output" >> "$output_to_file"
+    fi
+    # github-action limits output to 1MB
+    # we count bytes because unicode has multibyte characters
+    size=$(echo "$output" | wc -c)
+    if [ "$size" -ge "1000000" ]; then
+        echo "WARN: diff exceeds the 1MB limit, truncating output..." >&2
+        output=$(echo "$output" | head -c 1000000)
+    fi
+    echo "$output" >>"$GITHUB_OUTPUT"
+}

--- a/common/common.sh
+++ b/common/common.sh
@@ -1,7 +1,11 @@
 write_output () {
     local output="$1"
     if [ -n "$output_to_file" ]; then
-        echo "$output" >> "$output_to_file"
+        local file_output="$2"
+        if [ -z "$file_output" ]; then
+            file_output=$output
+        fi
+        echo "$file_output" >> "$output_to_file"
     fi
     # github-action limits output to 1MB
     # we count bytes because unicode has multibyte characters

--- a/diff/action.yml
+++ b/diff/action.yml
@@ -19,6 +19,13 @@ inputs:
     description: 'Include path parameter names in endpoint matching'
     required: false
     default: 'false'
+  exclude-elements:
+    description: 'Exclude certain kinds of changes'
+    required: false
+    default: ''
+outputs:
+  diff:
+    description: 'Output summary of API diff'
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -28,3 +35,4 @@ runs:
     - ${{ inputs.format }}
     - ${{ inputs.fail-on-diff }}
     - ${{ inputs.include-path-params }}
+    - ${{ inputs.exclude-elements }}

--- a/diff/action.yml
+++ b/diff/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: 'Exclude certain kinds of changes'
     required: false
     default: ''
+  output-to-file:
+    description: 'Output to a file at the given path'
+    required: false
+    default: ''
 outputs:
   diff:
     description: 'Output summary of API diff'
@@ -36,3 +40,4 @@ runs:
     - ${{ inputs.fail-on-diff }}
     - ${{ inputs.include-path-params }}
     - ${{ inputs.exclude-elements }}
+    - ${{ inputs.output-to-file }}

--- a/diff/entrypoint.sh
+++ b/diff/entrypoint.sh
@@ -39,9 +39,9 @@ echo "diff<<$delimiter" >>$GITHUB_OUTPUT
 set -o pipefail
 
 if [ -n "$flags" ]; then
-    output=$(oasdiff diff "$base" "$revision" $flags | head -n 1)
+    output=$(oasdiff diff "$base" "$revision" $flags)
 else
-    output=$(oasdiff diff "$base" "$revision" | head -n 1)
+    output=$(oasdiff diff "$base" "$revision")
 fi
 
 if [ -n "$output" ]; then
@@ -49,7 +49,7 @@ if [ -n "$output" ]; then
     # we count bytes because unicode has multibyte characters
     size=$(echo "$output" | wc -c)
     if [ "$size" -ge "1000000" ]; then
-        echo "WARN: breaking exceeds the 1MB limit, truncating output..." >&2
+        echo "WARN: diff exceeds the 1MB limit, truncating output..." >&2
         output=$(echo "$output" | head -c $1000000)
     fi
     echo "$output" >>$GITHUB_OUTPUT

--- a/diff/entrypoint.sh
+++ b/diff/entrypoint.sh
@@ -12,7 +12,7 @@ readonly exclude_elements="$6"
 readonly composed="$7"
 readonly output_to_file="$8"
 
-echo "running oasdiff diff base: $base, revision: $revision, format: $format, fail_on_diff: $fail_on_diff, include_path_params: $include_path_params, exclude_elements: $exclude_elements"
+echo "running oasdiff diff base: $base, revision: $revision, format: $format, fail_on_diff: $fail_on_diff, include_path_params: $include_path_params, exclude_elements: $exclude_elements, composed: $composed, output_to_file: $output_to_file"
 
 # Build flags to pass in command
 flags=""

--- a/diff/entrypoint.sh
+++ b/diff/entrypoint.sh
@@ -6,8 +6,9 @@ readonly revision="$2"
 readonly format="$3"
 readonly fail_on_diff="$4"
 readonly include_path_params="$5"
+readonly exclude_elements="$6"
 
-echo "running oasdiff diff base: $base, revision: $revision, format: $format, fail_on_diff: $fail_on_diff, include_path_params: $include_path_params"
+echo "running oasdiff diff base: $base, revision: $revision, format: $format, fail_on_diff: $fail_on_diff, include_path_params: $include_path_params, exclude_elements: $exclude_elements"
 
 # Build flags to pass in command
 flags=""
@@ -20,12 +21,40 @@ fi
 if [ "$include_path_params" = "true" ]; then
     flags="${flags} --include-path-params"
 fi
+if [ "$exclude_elements" != "" ]; then
+    flags="${flags} --exclude-elements ${exclude_elements}"
+fi
 echo "flags: $flags"
+
+# *** github action step output ***
+
+# output name should be in the syntax of multiple lines:
+# {name}<<{delimiter}
+# {value}
+# {delimiter}
+# see: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
+delimiter=$(cat /proc/sys/kernel/random/uuid | tr -d '-')
+echo "diff<<$delimiter" >>$GITHUB_OUTPUT
 
 set -o pipefail
 
 if [ -n "$flags" ]; then
-    oasdiff diff "$base" "$revision" $flags
+    output=$(oasdiff diff "$base" "$revision" $flags | head -n 1)
 else
-    oasdiff diff "$base" "$revision"
+    output=$(oasdiff diff "$base" "$revision" | head -n 1)
 fi
+
+if [ -n "$output" ]; then
+    # github-action limits output to 1MB
+    # we count bytes because unicode has multibyte characters
+    size=$(echo "$output" | wc -c)
+    if [ "$size" -ge "1000000" ]; then
+        echo "WARN: breaking exceeds the 1MB limit, truncating output..." >&2
+        output=$(echo "$output" | head -c $1000000)
+    fi
+    echo "$output" >>$GITHUB_OUTPUT
+else
+    echo "No changes" >>$GITHUB_OUTPUT
+fi
+
+echo "$delimiter" >>$GITHUB_OUTPUT

--- a/diff/entrypoint.sh
+++ b/diff/entrypoint.sh
@@ -1,28 +1,31 @@
 #!/bin/sh
 set -e
 
+source $GITHUB_WORKSPACE/common/common.sh
+
 readonly base="$1"
 readonly revision="$2"
 readonly format="$3"
 readonly fail_on_diff="$4"
 readonly include_path_params="$5"
 readonly exclude_elements="$6"
+readonly output_to_file="$7"
 
 echo "running oasdiff diff base: $base, revision: $revision, format: $format, fail_on_diff: $fail_on_diff, include_path_params: $include_path_params, exclude_elements: $exclude_elements"
 
 # Build flags to pass in command
 flags=""
 if [ "$format" != "yaml" ]; then
-    flags="${flags} --format ${format}"
+    flags="$flags --format $format"
 fi
 if [ "$fail_on_diff" = "true" ]; then
-    flags="${flags} --fail-on-diff"
+    flags="$flags --fail-on-diff"
 fi
 if [ "$include_path_params" = "true" ]; then
-    flags="${flags} --include-path-params"
+    flags="$flags --include-path-params"
 fi
-if [ "$exclude_elements" != "" ]; then
-    flags="${flags} --exclude-elements ${exclude_elements}"
+if [ -n "$exclude_elements" ]; then
+    flags="$flags --exclude-elements $exclude_elements"
 fi
 echo "flags: $flags"
 
@@ -34,7 +37,7 @@ echo "flags: $flags"
 # {delimiter}
 # see: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
 delimiter=$(cat /proc/sys/kernel/random/uuid | tr -d '-')
-echo "diff<<$delimiter" >>$GITHUB_OUTPUT
+echo "diff<<$delimiter" >>"$GITHUB_OUTPUT"
 
 set -o pipefail
 
@@ -45,16 +48,9 @@ else
 fi
 
 if [ -n "$output" ]; then
-    # github-action limits output to 1MB
-    # we count bytes because unicode has multibyte characters
-    size=$(echo "$output" | wc -c)
-    if [ "$size" -ge "1000000" ]; then
-        echo "WARN: diff exceeds the 1MB limit, truncating output..." >&2
-        output=$(echo "$output" | head -c $1000000)
-    fi
-    echo "$output" >>$GITHUB_OUTPUT
+    write_output "$output"
 else
-    echo "No changes" >>$GITHUB_OUTPUT
+    write_output "No changes"
 fi
 
-echo "$delimiter" >>$GITHUB_OUTPUT
+echo "$delimiter" >>"$GITHUB_OUTPUT"

--- a/specs/base-exclude-elements.yaml
+++ b/specs/base-exclude-elements.yaml
@@ -1,0 +1,111 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore API
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    get:
+      summary: List all pets data
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 1000)
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: A paged array of pets
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      responses:
+        '201':
+          description: Null response
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /pets/{petId}:
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+    Pets:
+      type: array
+      items:
+        $ref: "#/components/schemas/Pet"
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string


### PR DESCRIPTION
Adding the option to output to file is a good way to circumvent Github's 1MB output limit and will also help with Github's issues around expanding variables containing unescaped special characters (often found in `pattern` regex fields in openapi specs).