### PR TITLE
feat: generate githubaction output before failing in case of breaking changes

### DIFF
--- a/breaking/entrypoint.sh
+++ b/breaking/entrypoint.sh
@@ -36,9 +36,6 @@ echo "running oasdiff breaking... base: $base, revision: $revision, fail_on_diff
 
 # Build flags to pass in command
 flags=""
-if [ "$fail_on_diff" = "true" ]; then
-    flags="$flags --fail-on WARN"
-fi
 if [ "$include_path_params" = "true" ]; then
     flags="$flags --include-path-params"
 fi
@@ -88,3 +85,7 @@ else
 fi
 
 echo "$delimiter" >>"$GITHUB_OUTPUT"
+
+if [ "$fail_on_diff" = "true" -a -n "$breaking_changes" ]; then
+    exit 1
+fi


### PR DESCRIPTION
### Motivation
As a user of the github breaking action, I was trying to use the example from the readme to create a workflow that would fail if a breaking change is introduced in a PR. Something like this:
```
- name: Running OpenAPI Spec diff action
  uses: oasdiff/oasdiff-action/breaking@main
  with:
    base: https://raw.githubusercontent.com/Tufin/oasdiff/main/data/openapi-test1.yaml
    revision: https://raw.githubusercontent.com/Tufin/oasdiff/main/data/openapi-test3.yaml
```
While this makes the workflow fail, it generates no output in the logs for the commit authors to review.

### Fix
In this PR, the fail_on_diff flag is not passed to the oasdiff invocation to prevent the workflow from stopping too early. Instead, it waits until the end to check if the flag is true and any breaking change is detected.