### PR TITLE
Use stable oasdiff docker image tag instead of main

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -76,6 +76,8 @@ jobs:
   oasdiff_breaking:
     runs-on: ubuntu-latest
     name: Test breaking changes
+    env:
+      OASDIFF_ACTION_TEST_EXPECTED_OUTPUT: "1 changes: 1 error, 0 warning, 0 info"
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -85,7 +87,6 @@ jobs:
         with:
           base: 'specs/base.yaml'
           revision: 'specs/revision-breaking.yaml'
-          fail-on-diff: false
           output-to-file: 'breaking.txt'
       - name: Test breaking changes action output
         run: |
@@ -94,8 +95,8 @@ jobs:
           ${{ steps.test_breaking_changes.outputs.breaking }}
           $delimiter
           )
-          if [ "$output" != "1 breaking changes: 1 error, 0 warning" ]; then
-            echo "Expected output '1 breaking changes: 1 error, 0 warning' but got '$output'" >&2
+          if [ "$output" != "$OASDIFF_ACTION_TEST_EXPECTED_OUTPUT" ]; then
+            echo "Expected output '$OASDIFF_ACTION_TEST_EXPECTED_OUTPUT' but got '$output'" >&2
             exit 1
           fi
       - name: Test breaking changes action output to file
@@ -105,13 +106,15 @@ jobs:
             exit 1
           fi
           output=$(cat breaking.txt | head -n 1)
-          if [[  "${output}" != "1 breaking changes: 1 error, 0 warning" ]]; then
-            echo "Expected output '1 breaking changes: 1 error, 0 warning' but got '${output}'" >&2
+          if [[  "${output}" != "$OASDIFF_ACTION_TEST_EXPECTED_OUTPUT" ]]; then
+            echo "Expected output '$OASDIFF_ACTION_TEST_EXPECTED_OUTPUT' but got '${output}'" >&2
             exit 1
           fi
   oasdiff_breaking_fail_on:
     runs-on: ubuntu-latest
     name: Test fail on breaking changes
+    env:
+      OASDIFF_ACTION_TEST_EXPECTED_OUTPUT: "2 changes: 0 error, 2 warning, 0 info"
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -130,8 +133,8 @@ jobs:
           ${{ steps.test_breaking_changes.outputs.breaking }}
           $delimiter
           )
-          if [ "$output" != "2 breaking changes: 0 error, 2 warning" ]; then
-            echo "Expected output '2 breaking changes: 0 error, 2 warning' but got '$output'" >&2
+          if [ "$output" != "$OASDIFF_ACTION_TEST_EXPECTED_OUTPUT" ]; then
+            echo "Expected output '$OASDIFF_ACTION_TEST_EXPECTED_OUTPUT' but got '$output'" >&2
             exit 1
           fi
       - name: Test breaking changes action output to file
@@ -141,13 +144,15 @@ jobs:
             exit 1
           fi
           output=$(cat breaking.txt | head -n 1)
-          if [[  "${output}" != "2 breaking changes: 0 error, 2 warning" ]]; then
-            echo "Expected output '2 breaking changes: 0 error, 2 warning' but got '${output}'" >&2
+          if [[  "${output}" != "$OASDIFF_ACTION_TEST_EXPECTED_OUTPUT" ]]; then
+            echo "Expected output '$OASDIFF_ACTION_TEST_EXPECTED_OUTPUT' but got '${output}'" >&2
             exit 1
           fi
   oasdiff_breaking_matching_delimiter_not_found:
       runs-on: ubuntu-latest
       name: Test breaking action with petsotre to validate no error of unable to process file command 'output' successfully and invalid value and matching delimiter not found
+      env:
+        OASDIFF_ACTION_TEST_EXPECTED_OUTPUT: "9 changes: 6 error, 3 warning, 0 info"
       steps:
         - name: checkout
           uses: actions/checkout@v4
@@ -157,7 +162,6 @@ jobs:
           with:
             base: 'specs/petstore-base.yaml'
             revision: 'specs/petstore-revision.yaml'
-            fail-on-diff: false
         - name: Test breaking changes action output
           run: |
             delimiter=$(cat /proc/sys/kernel/random/uuid | tr -d '-')
@@ -165,13 +169,15 @@ jobs:
             ${{ steps.test_breaking_changes_matching_delimiter_not_found.outputs.breaking }}
             $delimiter
             )
-            if [ "$output" != "9 breaking changes: 6 error, 3 warning" ]; then
-              echo "Expected output '9 breaking changes: 6 error, 3 warning' but got '$output'" >&2
+            if [ "$output" != "$OASDIFF_ACTION_TEST_EXPECTED_OUTPUT" ]; then
+              echo "Expected output '$OASDIFF_ACTION_TEST_EXPECTED_OUTPUT' but got '$output'" >&2
               exit 1
             fi
   oasdiff_breaking_composed:
     runs-on: ubuntu-latest
     name: Test breaking action with composed option
+    env:
+        OASDIFF_ACTION_TEST_EXPECTED_OUTPUT: "1 changes: 1 error, 0 warning, 0 info"
     steps:
         - name: checkout
           uses: actions/checkout@v4
@@ -181,8 +187,6 @@ jobs:
           with:
             base: 'specs/glob/base/*.yaml'
             revision: 'specs/glob/revision/*.yaml'
-            fail-on-diff: false
-            format: 'text'
             composed: true
         - name: Test breaking action output
           run: |
@@ -191,8 +195,8 @@ jobs:
             ${{ steps.test_breaking_composed.outputs.breaking }}
             $delimiter
             )
-            if [[ ! "$output" =~ "1 breaking changes: 1 error, 0 warning" ]]; then
-              echo "Expected '1 breaking changes: 1 error, 0 warning', instead got '$output'" >&2
+            if [[ ! "$output" =~ "$OASDIFF_ACTION_TEST_EXPECTED_OUTPUT" ]]; then
+              echo "Expected '$OASDIFF_ACTION_TEST_EXPECTED_OUTPUT', instead got '$output'" >&2
               exit 1
             fi
   oasdiff_breaking_deprecation:
@@ -213,12 +217,13 @@ jobs:
         with:
           base: specs/base.yaml
           revision: specs/base-deprecation.yaml
-          fail-on-diff: true
           deprecation-days-beta: 14
           deprecation-days-stable: 21
   oasdiff_changelog:
     runs-on: ubuntu-latest
     name: Test generation of changelog
+    env:
+      OASDIFF_ACTION_TEST_EXPECTED_OUTPUT: "21 changes: 2 error, 4 warning, 15 info"
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -231,10 +236,9 @@ jobs:
           output-to-file: "changelog.txt"
       - name: Test changelog action output
         run: |
-          readonly expected_output="20 changes: 2 error, 4 warning, 14 info"
           output=$(echo "${{steps.test_changelog.outputs.changelog}}" | head -n 1)
-          if [[  "${output}" != "${expected_output}" ]]; then
-            echo "Expected output '20 changes: 2 error, 4 warning, 14 info' but got '${output}'" >&2
+          if [[  "${output}" != "${OASDIFF_ACTION_TEST_EXPECTED_OUTPUT}" ]]; then
+            echo "Expected output '$OASDIFF_ACTION_TEST_EXPECTED_OUTPUT' but got '${output}'" >&2
             exit 1
           fi
       - name: Test changelog action output to file
@@ -244,8 +248,8 @@ jobs:
             exit 1
           fi
           output=$(cat changelog.txt | head -n 1)
-          if [[  "${output}" != "20 changes: 2 error, 4 warning, 14 info" ]]; then
-            echo "Expected output '20 changes: 2 error, 4 warning, 14 info' but got '${output}'" >&2
+          if [[  "${output}" != "${OASDIFF_ACTION_TEST_EXPECTED_OUTPUT}" ]]; then
+            echo "Expected output '$OASDIFF_ACTION_TEST_EXPECTED_OUTPUT' but got '${output}'" >&2
             exit 1
           fi
   oasdiff_changelog_composed:
@@ -260,7 +264,6 @@ jobs:
           with:
             base: 'specs/glob/base/*.yaml'
             revision: 'specs/glob/revision/*.yaml'
-            format: 'text'
             composed: true
         - name: Test changelog action output
           run: |

--- a/breaking/Dockerfile
+++ b/breaking/Dockerfile
@@ -1,4 +1,4 @@
-FROM tufin/oasdiff:main
+FROM tufin/oasdiff:stable
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/changelog/Dockerfile
+++ b/changelog/Dockerfile
@@ -1,4 +1,4 @@
-FROM tufin/oasdiff:main
+FROM tufin/oasdiff:stable
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/diff/Dockerfile
+++ b/diff/Dockerfile
@@ -1,4 +1,4 @@
-FROM tufin/oasdiff:main
+FROM tufin/oasdiff:stable
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Currently the action uses the `main` tag for base docker image `tufin/oasdiff`, however it seems the `latest` tag is more suitable - it is updated together with the release of latest versions, while the `main` tag lags behind. See https://hub.docker.com/r/tufin/oasdiff/tags