### PR TITLE
Modify entrypoint.sh to handle exit codes

### DIFF
--- a/diff/entrypoint.sh
+++ b/diff/entrypoint.sh
@@ -62,16 +62,22 @@ echo "diff<<$delimiter" >>"$GITHUB_OUTPUT"
 
 set -o pipefail
 
+# Capture the exit code from oasdiff command while still getting the output
+exit_code=0
 if [ -n "$flags" ]; then
-    output=$(oasdiff diff "$base" "$revision" $flags)
+    output=$(oasdiff diff "$base" "$revision" $flags) || exit_code=$?
 else
-    output=$(oasdiff diff "$base" "$revision")
+    output=$(oasdiff diff "$base" "$revision") || exit_code=$?
 fi
 
 if [ -n "$output" ]; then
-    write_output "$output"
+    write_output "$output" >>"$GITHUB_OUTPUT"
 else
-    write_output "No changes"
+    write_output "No changes" >>"$GITHUB_OUTPUT"
 fi
 
+# Always close the multiline output format properly
 echo "$delimiter" >>"$GITHUB_OUTPUT"
+
+# Exit with the original exit code from oasdiff
+exit $exit_code


### PR DESCRIPTION
Changes Made
Exit code capture: Added exit_code=0 initialization and || exit_code=$? to capture the exit code from the oasdiff command without causing the script to exit immediately due to set -e.

Continued execution: Even if oasdiff returns a non-zero exit code (when differences are found with --fail-on-diff), the script continues to execute and properly handles the output.

Output handling: Restored the redirection to $GITHUB_OUTPUT for both the diff output and "No changes" cases to ensure the content goes into the multiline output format.

Proper delimiter closure: The closing delimiter is always written to complete the GitHub Actions multiline output format.

Exit with original code: The script exits with the original exit code from oasdiff, preserving the intended behavior where the action fails when differences are found and --fail-on-diff is true.

How This Fixes the Issue
The original problem was that when oasdiff found differences and returned exit code 1 (with --fail-on-diff enabled), the set -e directive caused the script to immediately terminate before:

Writing the diff output to $GITHUB_OUTPUT
Writing the closing delimiter
This left GitHub Actions with an incomplete multiline output format, causing the "invalid format delimiter not found before end of file" error.