### PR TITLE
feat: support filter extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This action supports additional arguments. Most are converted to parameters for 
 | --format              | format              | yaml    |
 | --include-path-params | include-path-params | false   |
 | --exclude-elements    | exclude-elements    | ''      |
+| --filter-extension    | filter-extension    | ''      |
 | --composed            | composed            | false   |
 | N/A                   | output-to-file      | ''      |
 
@@ -47,6 +48,7 @@ Additional arguments:
 | --deprecation-days-beta   | deprecation-days-beta   | 31      |
 | --deprecation-days-stable | deprecation-days-stable | 180     |
 | --exclude-elements        | exclude-elements        | ''      |
+| --filter-extension        | filter-extension        | ''      |
 | --composed                | composed                | false   |
 | N/A                       | output-to-file          | ''      |
 
@@ -68,5 +70,6 @@ Additional arguments:
 | --------------------- | ------------------- | ------- |
 | --include-path-params | include-path-params | false   |
 | --exclude-elements    | exclude-elements    | ''      |
+| --filter-extension    | filter-extension    | ''      |
 | --composed            | composed            | false   |
 | N/A                   | output-to-file      | ''      |

--- a/breaking/action.yml
+++ b/breaking/action.yml
@@ -28,6 +28,10 @@ inputs:
     description: 'Exclude certain kinds of changes'
     required: false
     default: ''
+  filter-extension:
+    description: 'Exclude paths and operations with an OpenAPI Extension matching the given regular expression'
+    required: false
+    default: ''
   composed:
     description: 'Run in composed mode'
     required: false
@@ -51,5 +55,6 @@ runs:
     - ${{ inputs.deprecation-days-beta }}
     - ${{ inputs.deprecation-days-stable }}
     - ${{ inputs.exclude-elements }}
+    - ${{ inputs.filter-extension }}
     - ${{ inputs.composed }}
     - ${{ inputs.output-to-file }}

--- a/breaking/entrypoint.sh
+++ b/breaking/entrypoint.sh
@@ -9,8 +9,9 @@ readonly include_path_params="$5"
 readonly deprecation_days_beta="$6"
 readonly deprecation_days_stable="$7"
 readonly exclude_elements="$8"
-readonly composed="$9"
-readonly output_to_file="${10}"
+readonly filter_extension="$9"
+readonly composed="$10"
+readonly output_to_file="${11}"
 
 write_output () {
     _write_output_output="$1"
@@ -32,7 +33,7 @@ write_output () {
     echo "$_write_output_output" >>"$GITHUB_OUTPUT"
 }
 
-echo "running oasdiff breaking... base: $base, revision: $revision, fail_on: $fail_on, include_checks: $include_checks, include_path_params: $include_path_params, deprecation_days_beta: $deprecation_days_beta, deprecation_days_stable: $deprecation_days_stable, exclude_elements: $exclude_elements, composed: $composed, output_to_file: $output_to_file"
+echo "running oasdiff breaking... base: $base, revision: $revision, fail_on: $fail_on, include_checks: $include_checks, include_path_params: $include_path_params, deprecation_days_beta: $deprecation_days_beta, deprecation_days_stable: $deprecation_days_stable, exclude_elements: $exclude_elements, filter_extension: $filter_extension, composed: $composed, output_to_file: $output_to_file"
 
 # Build flags to pass in command
 flags=""
@@ -50,6 +51,9 @@ if [ -n "$deprecation_days_stable" ]; then
 fi
 if [ -n "$exclude_elements" ]; then
     flags="$flags --exclude-elements $exclude_elements"
+fi
+if [ -n "$filter_extension" ]; then
+    flags="$flags --filter-extension $filter_extension"
 fi
 if [ "$composed" = "true" ]; then
     flags="$flags -c"

--- a/changelog/action.yml
+++ b/changelog/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: 'Exclude certain kinds of changes'
     required: false
     default: ''
+  filter-extension:
+    description: 'Exclude paths and operations with an OpenAPI Extension matching the given regular expression'
+    required: false
+    default: ''
   composed:
     description: 'Run in composed mode'
     required: false
@@ -34,5 +38,6 @@ runs:
     - ${{ inputs.revision }}
     - ${{ inputs.include-path-params }}
     - ${{ inputs.exclude-elements }}
+    - ${{ inputs.filter-extension }}
     - ${{ inputs.composed }}
     - ${{ inputs.output-to-file }}

--- a/changelog/entrypoint.sh
+++ b/changelog/entrypoint.sh
@@ -24,10 +24,11 @@ readonly base="$1"
 readonly revision="$2"
 readonly include_path_params="$3"
 readonly exclude_elements="$4"
-readonly composed="$5"
-readonly output_to_file="$6"
+readonly filter_extension="$5"
+readonly composed="$6"
+readonly output_to_file="$7"
 
-echo "running oasdiff changelog base: $base, revision: $revision, include_path_params: $include_path_params, exclude_elements: $exclude_elements, composed: $composed, output_to_file: $output_to_file"
+echo "running oasdiff changelog base: $base, revision: $revision, include_path_params: $include_path_params, exclude_elements: $exclude_elements, filter_extension: $filter_extension, composed: $composed, output_to_file: $output_to_file"
 
 # Build flags to pass in command
 flags=""
@@ -36,6 +37,9 @@ if [ "$include_path_params" = "true" ]; then
 fi
 if [ -n "$exclude_elements" ]; then
     flags="$flags --exclude-elements $exclude_elements"
+fi
+if [ -n "$filter_extension" ]; then
+    flags="$flags --filter-extension $filter_extension"
 fi
 if [ "$composed" = "true" ]; then
     flags="$flags -c"

--- a/diff/action.yml
+++ b/diff/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: 'Exclude certain kinds of changes'
     required: false
     default: ''
+  filter-extension:
+    description: 'Exclude paths and operations with an OpenAPI Extension matching the given regular expression'
+    required: false
+    default: ''
   composed:
     description: 'Run in composed mode'
     required: false
@@ -44,5 +48,6 @@ runs:
     - ${{ inputs.fail-on-diff }}
     - ${{ inputs.include-path-params }}
     - ${{ inputs.exclude-elements }}
+    - ${{ inputs.filter-extension }}
     - ${{ inputs.composed }}
     - ${{ inputs.output-to-file }}

--- a/diff/entrypoint.sh
+++ b/diff/entrypoint.sh
@@ -26,10 +26,11 @@ readonly format="$3"
 readonly fail_on_diff="$4"
 readonly include_path_params="$5"
 readonly exclude_elements="$6"
-readonly composed="$7"
-readonly output_to_file="$8"
+readonly filter_extension="$7"
+readonly composed="$8"
+readonly output_to_file="$9"
 
-echo "running oasdiff diff base: $base, revision: $revision, format: $format, fail_on_diff: $fail_on_diff, include_path_params: $include_path_params, exclude_elements: $exclude_elements, composed: $composed, output_to_file: $output_to_file"
+echo "running oasdiff diff base: $base, revision: $revision, format: $format, fail_on_diff: $fail_on_diff, include_path_params: $include_path_params, exclude_elements: $exclude_elements, filter_extension: $filter_extension, composed: $composed, output_to_file: $output_to_file"
 
 # Build flags to pass in command
 flags=""
@@ -44,6 +45,9 @@ if [ "$include_path_params" = "true" ]; then
 fi
 if [ -n "$exclude_elements" ]; then
     flags="$flags --exclude-elements $exclude_elements"
+fi
+if [ -n "$filter_extension" ]; then
+    flags="$flags --filter-extension $filter_extension"
 fi
 if [ "$composed" = "true" ]; then
     flags="$flags -c"


### PR DESCRIPTION
Adds support for the `--filter-extension` flag for excluding endpoints that are marked with things like `x-beta` or `x-internal`.

See https://github.com/Tufin/oasdiff/blob/main/docs/FILTERING-ENDPOINTS.md#by-extension