### PR TITLE
feat: add pr-comment sub-action

### DIFF
--- a/pr-comment/Dockerfile
+++ b/pr-comment/Dockerfile
@@ -1,0 +1,5 @@
+FROM tufin/oasdiff:stable
+RUN apk add --no-cache curl jq
+ENV PLATFORM github-action
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/pr-comment/action.yml
+++ b/pr-comment/action.yml
@@ -1,0 +1,39 @@
+name: 'OpenAPI Spec: PR Comment'
+description: 'Post an oasdiff API change report as a PR comment'
+inputs:
+  base:
+    description: 'Path of original OpenAPI spec in YAML or JSON format'
+    required: true
+  revision:
+    description: 'Path of revised OpenAPI spec in YAML or JSON format'
+    required: true
+  include-path-params:
+    description: 'Include path parameter names in endpoint matching'
+    required: false
+    default: 'false'
+  exclude-elements:
+    description: 'Exclude certain kinds of changes'
+    required: false
+    default: ''
+  composed:
+    description: 'Run in composed mode'
+    required: false
+    default: 'false'
+  oasdiff-token:
+    description: 'oasdiff API token (tenant ID)'
+    required: true
+  github-token:
+    description: 'GitHub token for posting PR comment'
+    required: false
+    default: '${{ github.token }}'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.base }}
+    - ${{ inputs.revision }}
+    - ${{ inputs.include-path-params }}
+    - ${{ inputs.exclude-elements }}
+    - ${{ inputs.composed }}
+    - ${{ inputs.oasdiff-token }}
+    - ${{ inputs.github-token }}

--- a/pr-comment/entrypoint.sh
+++ b/pr-comment/entrypoint.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+set -e
+
+readonly base="$1"
+readonly revision="$2"
+readonly include_path_params="$3"
+readonly exclude_elements="$4"
+readonly composed="$5"
+readonly oasdiff_token="$6"
+readonly github_token="$7"
+
+echo "running oasdiff pr-comment base: $base, revision: $revision, include_path_params: $include_path_params, exclude_elements: $exclude_elements, composed: $composed"
+
+# Build flags
+flags=""
+if [ "$include_path_params" = "true" ]; then
+    flags="$flags --include-path-params"
+fi
+if [ -n "$exclude_elements" ]; then
+    flags="$flags --exclude-elements $exclude_elements"
+fi
+if [ "$composed" = "true" ]; then
+    flags="$flags -c"
+fi
+
+# Run oasdiff changelog with JSON output
+if [ -n "$flags" ]; then
+    changelog=$(oasdiff changelog "$base" "$revision" --format json $flags)
+else
+    changelog=$(oasdiff changelog "$base" "$revision" --format json)
+fi
+
+# If no changes, use empty array
+if [ -z "$changelog" ] || [ "$changelog" = "null" ]; then
+    changelog='{"changes":[]}'
+fi
+
+# Extract just the changes array
+changes=$(echo "$changelog" | jq -c '.changes // []')
+
+# Extract PR number from GITHUB_REF (refs/pull/{number}/merge)
+pr_number=$(echo "$GITHUB_REF" | sed -n 's|refs/pull/\([0-9]*\)/merge|\1|p')
+if [ -z "$pr_number" ]; then
+    echo "ERROR: Could not extract PR number from GITHUB_REF=$GITHUB_REF" >&2
+    echo "This action must be run on pull_request events." >&2
+    exit 1
+fi
+
+# Extract owner and repo from GITHUB_REPOSITORY
+owner="${GITHUB_REPOSITORY%%/*}"
+repo="${GITHUB_REPOSITORY#*/}"
+
+# Build the JSON payload
+payload=$(jq -n \
+    --arg token "$github_token" \
+    --arg owner "$owner" \
+    --arg repo "$repo" \
+    --argjson pr "$pr_number" \
+    --arg sha "$GITHUB_SHA" \
+    --argjson changes "$changes" \
+    '{github: {token: $token, owner: $owner, repo: $repo, pull_number: $pr, head_sha: $sha}, changes: $changes}')
+
+# POST to oasdiff-service
+response=$(curl -s -w "\n%{http_code}" -X POST \
+    "https://api.oasdiff.com/tenants/${oasdiff_token}/pr-comment" \
+    -H "Content-Type: application/json" \
+    -d "$payload")
+
+http_code=$(echo "$response" | tail -1)
+body=$(echo "$response" | sed '$d')
+
+if [ "$http_code" -ge 200 ] && [ "$http_code" -lt 300 ]; then
+    comment_url=$(echo "$body" | jq -r '.comment_url // empty')
+    echo "PR comment posted: $comment_url"
+else
+    echo "ERROR: oasdiff-service returned HTTP $http_code" >&2
+    echo "$body" >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- New `pr-comment/` sub-action that posts an oasdiff API change report as a PR comment
- Runs `oasdiff changelog --format json` locally (specs stay on the runner), then POSTs the JSON to `api.oasdiff.com` which renders and posts the markdown comment
- Supports all standard oasdiff flags: `include-path-params`, `exclude-elements`, `composed`
- Requires `oasdiff-token` (tenant ID) and uses `github.token` by default for posting

**Depends on:** oasdiff/oasdiff-service#103 (the service endpoint)

### Usage

```yaml
- uses: oasdiff/oasdiff-action/pr-comment@main
  with:
    base: specs/base.yaml
    revision: specs/revision.yaml
    oasdiff-token: ${{ secrets.OASDIFF_TOKEN }}
```

## Test plan

- [ ] Build Docker image and verify entrypoint runs
- [ ] End-to-end: test with a real PR after service endpoint is deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)