### PR TITLE
Add oasdiff breaking change detection

### DIFF
--- a/.github/workflows/oasdiff.yml
+++ b/.github/workflows/oasdiff.yml
@@ -1,0 +1,19 @@
+name: oasdiff
+
+on:
+  pull_request:
+
+permissions:
+  pull-requests: write
+
+jobs:
+  oasdiff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oasdiff/oasdiff-action/pr-comment@v0.0.31
+        with:
+          base: 'origin/${{ github.base_ref }}:simple.yaml'
+          revision: 'HEAD:simple.yaml'
+          oasdiff-token: ${{ secrets.OASDIFF_TOKEN }}


### PR DESCRIPTION
This PR adds the [oasdiff GitHub Action](https://github.com/oasdiff/oasdiff-action) to automatically detect breaking changes in your OpenAPI spec on every pull request.

Once merged, every PR that modifies your API spec will get an automatic comment listing any breaking changes.