### PR TITLE
fix: follow HTTP redirects in service request

### DIFF
--- a/pr-comment/entrypoint.sh
+++ b/pr-comment/entrypoint.sh
@@ -89,7 +89,7 @@ if [ -z "$oasdiff_token" ]; then
     exit 0
 fi
 
-response=$(curl -s -w "\n%{http_code}" -X POST \
+response=$(curl -s -L -w "\n%{http_code}" -X POST \
     "${service_url}/tenants/${oasdiff_token}/pr-comment" \
     -H "Content-Type: application/json" \
     -d "$payload")


### PR DESCRIPTION
## Summary
The `curl` call to `api.oasdiff.com` did not follow redirects (`-L` was missing), causing a 301 response to be treated as a fatal error. Adding `-L` makes curl follow any redirects transparently.

Fixes: https://github.com/blondinit/github-demo-copy/actions/runs/23316053696/job/67815723559

🤖 Generated with [Claude Code](https://claude.com/claude-code)