### PR TITLE
feat: add err-ignore and warn-ignore to breaking action

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -302,3 +302,27 @@ jobs:
             echo "Expected output '$OASDIFF_ACTION_TEST_EXPECTED_OUTPUT' but got '$output'" >&2
             exit 1
           fi
+  oasdiff_breaking_err_ignore:
+    runs-on: ubuntu-latest
+    name: Test breaking action with err-ignore option
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: Running breaking action with err-ignore option
+        id: test_breaking_err_ignore
+        uses: ./breaking
+        with:
+          base: 'specs/base.yaml'
+          revision: 'specs/revision-breaking.yaml'
+          err-ignore: 'specs/err-ignore.txt'
+      - name: Test breaking changes are suppressed
+        run: |
+          delimiter=$(cat /proc/sys/kernel/random/uuid | tr -d '-')
+          output=$(cat <<-$delimiter
+          ${{ steps.test_breaking_err_ignore.outputs.breaking }}
+          $delimiter
+          )
+          if [ "$output" != "No breaking changes" ]; then
+            echo "Expected 'No breaking changes' but got '$output'" >&2
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ jobs:
 | `filter-extension` | `''` | Exclude paths and operations with an OpenAPI Extension matching this expression | regex |
 | `composed` | `false` | Run in composed mode | `true`, `false` |
 | `flatten-allof` | `false` | Merge allOf subschemas into a single schema before diff | `true`, `false` |
+| `err-ignore` | `''` | Path to a file containing regex patterns for error-level changes to ignore | file path |
+| `warn-ignore` | `''` | Path to a file containing regex patterns for warning-level changes to ignore | file path |
 | `output-to-file` | `''` | Write output to this file path instead of stdout | file path |
 
 ### Generate a changelog

--- a/breaking/action.yml
+++ b/breaking/action.yml
@@ -40,6 +40,14 @@ inputs:
     description: 'Merge allOf subschemas into a single schema before diff'
     required: false
     default: 'false'
+  err-ignore:
+    description: 'Path to a file containing regex patterns for error-level changes to ignore'
+    required: false
+    default: ''
+  warn-ignore:
+    description: 'Path to a file containing regex patterns for warning-level changes to ignore'
+    required: false
+    default: ''
   output-to-file:
     description: 'Output to a file at the given path'
     required: false
@@ -62,4 +70,6 @@ runs:
     - ${{ inputs.filter-extension }}
     - ${{ inputs.composed }}
     - ${{ inputs.flatten-allof }}
+    - ${{ inputs.err-ignore }}
+    - ${{ inputs.warn-ignore }}
     - ${{ inputs.output-to-file }}

--- a/breaking/entrypoint.sh
+++ b/breaking/entrypoint.sh
@@ -17,7 +17,9 @@ readonly exclude_elements="$8"
 readonly filter_extension="$9"
 readonly composed="${10}"
 readonly flatten_allof="${11}"
-readonly output_to_file="${12}"
+readonly err_ignore="${12}"
+readonly warn_ignore="${13}"
+readonly output_to_file="${14}"
 
 write_output () {
     _write_output_output="$1"
@@ -39,7 +41,7 @@ write_output () {
     echo "$_write_output_output" >>"$GITHUB_OUTPUT"
 }
 
-echo "running oasdiff breaking... base: $base, revision: $revision, fail_on: $fail_on, include_checks: $include_checks, include_path_params: $include_path_params, deprecation_days_beta: $deprecation_days_beta, deprecation_days_stable: $deprecation_days_stable, exclude_elements: $exclude_elements, filter_extension: $filter_extension, composed: $composed, flatten_allof: $flatten_allof, output_to_file: $output_to_file"
+echo "running oasdiff breaking... base: $base, revision: $revision, fail_on: $fail_on, include_checks: $include_checks, include_path_params: $include_path_params, deprecation_days_beta: $deprecation_days_beta, deprecation_days_stable: $deprecation_days_stable, exclude_elements: $exclude_elements, filter_extension: $filter_extension, composed: $composed, flatten_allof: $flatten_allof, err_ignore: $err_ignore, warn_ignore: $warn_ignore, output_to_file: $output_to_file"
 
 # Build flags to pass in command
 flags=""
@@ -66,6 +68,12 @@ if [ "$composed" = "true" ]; then
 fi
 if [ "$flatten_allof" = "true" ]; then
     flags="$flags --flatten-allof"
+fi
+if [ -n "$err_ignore" ]; then
+    flags="$flags --err-ignore $err_ignore"
+fi
+if [ -n "$warn_ignore" ]; then
+    flags="$flags --warn-ignore $warn_ignore"
 fi
 echo "flags: $flags"
 

--- a/specs/err-ignore.txt
+++ b/specs/err-ignore.txt
@@ -1,1 +1,1 @@
-endpoint-deleted
+GET /pets api removed without deprecation

--- a/specs/err-ignore.txt
+++ b/specs/err-ignore.txt
@@ -1,0 +1,1 @@
+endpoint-deleted


### PR DESCRIPTION
Closes #66

Exposes `--err-ignore` and `--warn-ignore` as inputs on the `breaking` action, letting users suppress specific false-positive changes by providing a file of regex patterns.

## Changes

- **`breaking/action.yml`**: add `err-ignore` and `warn-ignore` inputs
- **`breaking/entrypoint.sh`**: pass `--err-ignore` / `--warn-ignore` flags when set
- **`specs/err-ignore.txt`**: test fixture — ignores `endpoint-deleted`
- **`.github/workflows/test.yaml`**: add `oasdiff_breaking_err_ignore` job that verifies the error is suppressed
- **`README.md`**: add `err-ignore` and `warn-ignore` rows to the breaking action table

## Test plan
- [x] CI passes with new `oasdiff_breaking_err_ignore` test job
- [x] With `err-ignore: specs/err-ignore.txt`, a spec pair that normally produces 1 error returns `No breaking changes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)