### PR TITLE
feat: emit ::notice:: upgrade link when breaking changes are found

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Each **Review** link opens a hosted page with a side-by-side spec diff and **App
 |---|---|---|---|
 | `base` | — (required) | Path to the base (old) OpenAPI spec | file path, URL, git ref |
 | `revision` | — (required) | Path to the revised (new) OpenAPI spec | file path, URL, git ref |
-| `oasdiff-token` | — (required) | oasdiff API token — [sign up at oasdiff.com](https://oasdiff.com) | — |
+| `oasdiff-token` | — (required) | oasdiff API token — [get one at oasdiff.com/pricing](https://oasdiff.com/pricing) | — |
 | `github-token` | `${{ github.token }}` | GitHub token for posting the PR comment; requires `pull-requests: write`, `statuses: write` | — |
 | `include-path-params` | `false` | Include path parameter names in endpoint matching | `true`, `false` |
 | `exclude-elements` | `''` | Exclude certain kinds of changes from the output | `endpoints`, `request`, `response` (comma-separated) |

--- a/breaking/Dockerfile
+++ b/breaking/Dockerfile
@@ -1,4 +1,5 @@
 FROM tufin/oasdiff:stable
+RUN apk add --no-cache jq
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/breaking/entrypoint.sh
+++ b/breaking/entrypoint.sh
@@ -101,6 +101,16 @@ echo "breaking<<$delimiter" >>"$GITHUB_OUTPUT"
 
 if [ -n "$breaking_changes" ]; then
     write_output "$(echo "$breaking_changes" | head -n 1)" "$breaking_changes"
+    # Emit upgrade notice pointing to the free review page
+    urlencode() { printf '%s' "$1" | jq -sRr @uri; }
+    base_path=$(echo "$base" | sed 's/.*://')
+    rev_path=$(echo "$revision" | sed 's/.*://')
+    owner="${GITHUB_REPOSITORY%%/*}"
+    repo="${GITHUB_REPOSITORY#*/}"
+    head_sha=$(jq -r '.pull_request.head.sha // empty' "$GITHUB_EVENT_PATH" 2>/dev/null || echo "")
+    if [ -z "$head_sha" ]; then head_sha="$GITHUB_SHA"; fi
+    free_review_url="https://www.oasdiff.com/review?owner=${owner}&repo=${repo}&base_sha=$(urlencode "$GITHUB_BASE_REF")&rev_sha=${head_sha}&base_file=$(urlencode "$base_path")&rev_file=$(urlencode "$rev_path")"
+    echo "::notice::📋 Review & approve these breaking changes → ${free_review_url}"
 else
     write_output "No breaking changes"
 fi


### PR DESCRIPTION
## Summary

When the `breaking` action finds breaking changes, it now emits a `::notice::` annotation linking to a free review page at `oasdiff.com/review`. The page shows a side-by-side spec diff with the full change list, locked 🔒 approve/reject buttons, and an upgrade CTA.

Changes:
- **`breaking/Dockerfile`**: add `jq` (needed for URL encoding and PR head SHA extraction)
- **`breaking/entrypoint.sh`**: emit `::notice::` with free review URL only when breaking changes are found
- **`README.md`**: update `oasdiff-token` link to point directly to `/pricing`

## Funnel flow

```
breaking changes found
  → ::notice::📋 Review & approve these breaking changes → oasdiff.com/review?...
    → free review page: side-by-side diff + change list + locked approve/reject
      → "Start free trial →" upgrade CTA
```

The notice only fires when there are actual breaking changes — clean runs stay silent.

Depends on: oasdiff/w3#21 (free review page), oasdiff/oasdiff-service#131 (`POST /public/changelog`)

## Test plan
- [ ] Run against a spec pair with breaking changes — `::notice::` appears in Actions log
- [ ] Run against identical specs — no `::notice::` emitted
- [ ] Link in notice opens the free review page with the correct specs loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)