### PR TITLE
docs: add GitHub App install prerequisite and remove permissions block

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,13 +129,12 @@ File paths and git refs require the repository to be checked out first:
 
 `oasdiff/oasdiff-action/pr-comment@v0.0.37` posts a single auto-updating comment on every PR that touches your API spec.
 
+**Prerequisite:** oasdiff posts comments and commit statuses as a GitHub App. [Install the oasdiff GitHub App](https://github.com/apps/oasdiff/installations/new) on each repository before using this action.
+
 ```yaml
 jobs:
   oasdiff:
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      statuses: write
     steps:
       - uses: oasdiff/oasdiff-action/pr-comment@v0.0.37
         with:


### PR DESCRIPTION
## Summary

- Added **prerequisite note** to the Pro section: install the oasdiff GitHub App on each repository before using `pr-comment`
- Removed the `permissions: pull-requests: write / statuses: write` block from the `pr-comment` workflow snippet — these are no longer required since oasdiff now writes via a GitHub App installation token, not the workflow's `GITHUB_TOKEN`

## Why

oasdiff-service was migrated to use a GitHub App for all bot writes (PR comments, commit statuses). The workflow-level permissions block was a workaround for the old OAuth App approach and is now misleading. Users also need to know to install the App before the action will work.

## Test plan

- [ ] Verify `pr-comment` workflow without `permissions` block still posts comments and commit statuses correctly (GitHub App handles the writes)
- [ ] Verify install link points to `https://github.com/apps/oasdiff/installations/new`

🤖 Generated with [Claude Code](https://claude.com/claude-code)