### PR TITLE
fix: pin oasdiff Docker image to v1.13.5 instead of floating :stable tag

### DIFF
--- a/breaking/Dockerfile
+++ b/breaking/Dockerfile
@@ -1,4 +1,4 @@
-FROM tufin/oasdiff:stable
+FROM tufin/oasdiff:v1.13.5
 RUN apk add --no-cache jq
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh

--- a/changelog/Dockerfile
+++ b/changelog/Dockerfile
@@ -1,4 +1,4 @@
-FROM tufin/oasdiff:stable
+FROM tufin/oasdiff:v1.13.5
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/diff/Dockerfile
+++ b/diff/Dockerfile
@@ -1,4 +1,4 @@
-FROM tufin/oasdiff:stable
+FROM tufin/oasdiff:v1.13.5
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/pr-comment/Dockerfile
+++ b/pr-comment/Dockerfile
@@ -1,4 +1,4 @@
-FROM tufin/oasdiff:stable
+FROM tufin/oasdiff:v1.13.5
 RUN apk add --no-cache curl jq
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
## Summary

- Pins `FROM tufin/oasdiff:stable` to `FROM tufin/oasdiff:v1.13.5` in all four Dockerfiles (`breaking/`, `changelog/`, `diff/`, `pr-comment/`)
- Improves reproducibility: pinning the action commit now also pins the oasdiff CLI version
- Reduces supply chain risk: floating `:stable` tag could be updated or compromised without any visible change in the consumer's lockfile

Closes #88