### PR TITLE
fix: handle informational messages from oasdiff v1.14.0

### DIFF
--- a/breaking/entrypoint.sh
+++ b/breaking/entrypoint.sh
@@ -99,7 +99,7 @@ oasdiff breaking "$base" "$revision" $flags_with_githubactions
 delimiter=$(cat /proc/sys/kernel/random/uuid | tr -d '-')
 echo "breaking<<$delimiter" >>"$GITHUB_OUTPUT"
 
-if [ -n "$breaking_changes" ]; then
+if [ -n "$breaking_changes" ] && ! echo "$breaking_changes" | head -n 1 | grep -q "^No "; then
     write_output "$(echo "$breaking_changes" | head -n 1)" "$breaking_changes"
     # Emit upgrade notice pointing to the free review page
     urlencode() { printf '%s' "$1" | jq -sRr @uri; }

--- a/changelog/entrypoint.sh
+++ b/changelog/entrypoint.sh
@@ -97,7 +97,7 @@ else
     output=$(oasdiff changelog "$base" "$revision")
 fi
 
-if [ -n "$output" ]; then
+if [ -n "$output" ] && ! echo "$output" | head -n 1 | grep -q "^No "; then
     write_output "$output"
 else
     write_output "No changelog changes"


### PR DESCRIPTION
## Summary
- oasdiff v1.14.0 now prints `"No changes to report, but the specs are different"` when the diff is non-empty but no breaking/changelog entries are found (e.g. all suppressed via `--err-ignore`)
- The entrypoint scripts treated any non-empty stdout as actual changes, which caused the `::notice::` upgrade link to fire incorrectly and output the wrong string
- Fix: skip output lines starting with `"No "` — these are informational messages, not actual changes

## Test plan
- [ ] CI test `oasdiff_breaking_err_ignore` should pass (currently failing)
- [ ] Verify no regression on other test scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)