### PR TITLE
feat: OpenAPI 3.1 support

### DIFF
--- a/breaking/Dockerfile
+++ b/breaking/Dockerfile
@@ -1,4 +1,4 @@
-FROM tufin/oasdiff:v1.14.0
+FROM tufin/oasdiff:v1.15.0-openapi31.beta.1
 RUN apk add --no-cache jq
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh

--- a/changelog/Dockerfile
+++ b/changelog/Dockerfile
@@ -1,4 +1,4 @@
-FROM tufin/oasdiff:v1.14.0
+FROM tufin/oasdiff:v1.15.0-openapi31.beta.1
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/diff/Dockerfile
+++ b/diff/Dockerfile
@@ -1,4 +1,4 @@
-FROM tufin/oasdiff:v1.14.0
+FROM tufin/oasdiff:v1.15.0-openapi31.beta.1
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/pr-comment/Dockerfile
+++ b/pr-comment/Dockerfile
@@ -1,4 +1,4 @@
-FROM tufin/oasdiff:v1.14.0
+FROM tufin/oasdiff:v1.15.0-openapi31.beta.1
 RUN apk add --no-cache curl jq
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
## Summary
- Update all Dockerfiles to use `tufin/oasdiff:v1.15.0-openapi31.beta.1`
- Matches oasdiff-service PR #166

## What this enables
- All actions (diff, breaking, changelog, pr-comment) will correctly handle OpenAPI 3.1 specs
- 3.0.x specs continue to work exactly as before

## Test plan
- [ ] CI passes (existing tests use 3.0.x specs, verifying backward compatibility)

🤖 Generated with [Claude Code](https://claude.com/claude-code)