### PR TITLE
docs: bump README to v0.0.40-beta.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ jobs:
   oasdiff:
     runs-on: ubuntu-latest
     steps:
-      - uses: oasdiff/oasdiff-action/breaking@v0.0.39
+      - uses: oasdiff/oasdiff-action/breaking@v0.0.40-beta.1
         with:
           base: 'specs/base.yaml'
           revision: 'specs/revision.yaml'
@@ -47,7 +47,7 @@ jobs:
   oasdiff:
     runs-on: ubuntu-latest
     steps:
-      - uses: oasdiff/oasdiff-action/changelog@v0.0.39
+      - uses: oasdiff/oasdiff-action/changelog@v0.0.40-beta.1
         with:
           base: 'specs/base.yaml'
           revision: 'specs/revision.yaml'
@@ -79,7 +79,7 @@ jobs:
   oasdiff:
     runs-on: ubuntu-latest
     steps:
-      - uses: oasdiff/oasdiff-action/diff@v0.0.39
+      - uses: oasdiff/oasdiff-action/diff@v0.0.40-beta.1
         with:
           base: 'specs/base.yaml'
           revision: 'specs/revision.yaml'
@@ -115,7 +115,7 @@ File paths and git refs require the repository to be checked out first:
 ```yaml
 - uses: actions/checkout@v6
 - run: git fetch --depth=1 origin ${{ github.base_ref }}
-- uses: oasdiff/oasdiff-action/breaking@v0.0.39
+- uses: oasdiff/oasdiff-action/breaking@v0.0.40-beta.1
   with:
     base: 'origin/${{ github.base_ref }}:openapi.yaml'
     revision: 'HEAD:openapi.yaml'
@@ -127,7 +127,7 @@ File paths and git refs require the repository to be checked out first:
 
 ## Pro: Rich PR comment
 
-`oasdiff/oasdiff-action/pr-comment@v0.0.39` posts a single auto-updating comment on every PR that touches your API spec.
+`oasdiff/oasdiff-action/pr-comment@v0.0.40-beta.1` posts a single auto-updating comment on every PR that touches your API spec.
 
 **Prerequisite:** oasdiff posts comments and commit statuses as a GitHub App. [Install the oasdiff GitHub App](https://github.com/apps/oasdiff/installations/new) on each repository before using this action.
 
@@ -136,7 +136,7 @@ jobs:
   oasdiff:
     runs-on: ubuntu-latest
     steps:
-      - uses: oasdiff/oasdiff-action/pr-comment@v0.0.39
+      - uses: oasdiff/oasdiff-action/pr-comment@v0.0.40-beta.1
         with:
           base: 'specs/base.yaml'
           revision: 'specs/revision.yaml'


### PR DESCRIPTION
## Summary
- Update all version references in README from v0.0.39 to v0.0.40-beta.1 (OpenAPI 3.1 support)

🤖 Generated with [Claude Code](https://claude.com/claude-code)