### PR TITLE
chore: bump Docker image to v1.15.0-openapi31.beta.2

### DIFF
--- a/breaking/Dockerfile
+++ b/breaking/Dockerfile
@@ -1,4 +1,4 @@
-FROM tufin/oasdiff:v1.15.0-openapi31.beta.1
+FROM tufin/oasdiff:v1.15.0-openapi31.beta.2
 RUN apk add --no-cache jq
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh

--- a/changelog/Dockerfile
+++ b/changelog/Dockerfile
@@ -1,4 +1,4 @@
-FROM tufin/oasdiff:v1.15.0-openapi31.beta.1
+FROM tufin/oasdiff:v1.15.0-openapi31.beta.2
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/diff/Dockerfile
+++ b/diff/Dockerfile
@@ -1,4 +1,4 @@
-FROM tufin/oasdiff:v1.15.0-openapi31.beta.1
+FROM tufin/oasdiff:v1.15.0-openapi31.beta.2
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/pr-comment/Dockerfile
+++ b/pr-comment/Dockerfile
@@ -1,4 +1,4 @@
-FROM tufin/oasdiff:v1.15.0-openapi31.beta.1
+FROM tufin/oasdiff:v1.15.0-openapi31.beta.2
 RUN apk add --no-cache curl jq
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
## Summary
- Updates all 4 Dockerfiles from `tufin/oasdiff:v1.15.0-openapi31.beta.1` to `v1.15.0-openapi31.beta.2`
- Picks up Origin json tag fix (PR #1149) and yaml3 v0.0.12 (mapping field origin tracking)

## Test plan
- [ ] Docker image `tufin/oasdiff:v1.15.0-openapi31.beta.2` must exist before merging (build in progress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)