### PR TITLE
chore: bump oasdiff Docker image to v1.15.0-openapi31.beta.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ jobs:
   oasdiff:
     runs-on: ubuntu-latest
     steps:
-      - uses: oasdiff/oasdiff-action/breaking@v0.0.40-beta.2
+      - uses: oasdiff/oasdiff-action/breaking@v0.0.40-beta.3
         with:
           base: 'specs/base.yaml'
           revision: 'specs/revision.yaml'
@@ -47,7 +47,7 @@ jobs:
   oasdiff:
     runs-on: ubuntu-latest
     steps:
-      - uses: oasdiff/oasdiff-action/changelog@v0.0.40-beta.2
+      - uses: oasdiff/oasdiff-action/changelog@v0.0.40-beta.3
         with:
           base: 'specs/base.yaml'
           revision: 'specs/revision.yaml'
@@ -79,7 +79,7 @@ jobs:
   oasdiff:
     runs-on: ubuntu-latest
     steps:
-      - uses: oasdiff/oasdiff-action/diff@v0.0.40-beta.2
+      - uses: oasdiff/oasdiff-action/diff@v0.0.40-beta.3
         with:
           base: 'specs/base.yaml'
           revision: 'specs/revision.yaml'
@@ -115,7 +115,7 @@ File paths and git refs require the repository to be checked out first:
 ```yaml
 - uses: actions/checkout@v6
 - run: git fetch --depth=1 origin ${{ github.base_ref }}
-- uses: oasdiff/oasdiff-action/breaking@v0.0.40-beta.2
+- uses: oasdiff/oasdiff-action/breaking@v0.0.40-beta.3
   with:
     base: 'origin/${{ github.base_ref }}:openapi.yaml'
     revision: 'HEAD:openapi.yaml'
@@ -127,7 +127,7 @@ File paths and git refs require the repository to be checked out first:
 
 ## Pro: Rich PR comment
 
-`oasdiff/oasdiff-action/pr-comment@v0.0.40-beta.2` posts a single auto-updating comment on every PR that touches your API spec.
+`oasdiff/oasdiff-action/pr-comment@v0.0.40-beta.3` posts a single auto-updating comment on every PR that touches your API spec.
 
 **Prerequisite:** oasdiff posts comments and commit statuses as a GitHub App. [Install the oasdiff GitHub App](https://github.com/apps/oasdiff/installations/new) on each repository before using this action.
 
@@ -136,7 +136,7 @@ jobs:
   oasdiff:
     runs-on: ubuntu-latest
     steps:
-      - uses: oasdiff/oasdiff-action/pr-comment@v0.0.40-beta.2
+      - uses: oasdiff/oasdiff-action/pr-comment@v0.0.40-beta.3
         with:
           base: 'specs/base.yaml'
           revision: 'specs/revision.yaml'

--- a/breaking/Dockerfile
+++ b/breaking/Dockerfile
@@ -1,4 +1,4 @@
-FROM tufin/oasdiff:v1.15.0-openapi31.beta.2
+FROM tufin/oasdiff:v1.15.0-openapi31.beta.3
 RUN apk add --no-cache jq
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh

--- a/changelog/Dockerfile
+++ b/changelog/Dockerfile
@@ -1,4 +1,4 @@
-FROM tufin/oasdiff:v1.15.0-openapi31.beta.2
+FROM tufin/oasdiff:v1.15.0-openapi31.beta.3
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/diff/Dockerfile
+++ b/diff/Dockerfile
@@ -1,4 +1,4 @@
-FROM tufin/oasdiff:v1.15.0-openapi31.beta.2
+FROM tufin/oasdiff:v1.15.0-openapi31.beta.3
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/pr-comment/Dockerfile
+++ b/pr-comment/Dockerfile
@@ -1,4 +1,4 @@
-FROM tufin/oasdiff:v1.15.0-openapi31.beta.2
+FROM tufin/oasdiff:v1.15.0-openapi31.beta.3
 RUN apk add --no-cache curl jq
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
## Summary
- Bump Docker image tag from `tufin/oasdiff:v1.15.0-openapi31.beta.2` to `tufin/oasdiff:v1.15.0-openapi31.beta.3` in all four Dockerfiles (breaking, changelog, diff, pr-comment)

## Test plan
- [ ] Verify the Docker image `tufin/oasdiff:v1.15.0-openapi31.beta.3` exists on Docker Hub
- [ ] Run each action (breaking, changelog, diff, pr-comment) against a test repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)