### PR TITLE
feat(pr-comment): capture pull_request.base.sha as base_sha

### DIFF
--- a/pr-comment/entrypoint.sh
+++ b/pr-comment/entrypoint.sh
@@ -58,6 +58,13 @@ if [ -z "$head_sha" ]; then
     head_sha="$GITHUB_SHA"
 fi
 
+# Capture the PR base SHA (the commit the PR is opened against). Pinning to
+# the SHA gives the review page a stable base reference: if the base branch
+# advances after the PR was opened, the review still shows the comparison
+# against the original base. base_ref is still sent for backward compatibility
+# with reports that don't yet have base_sha.
+base_sha=$(jq -r '.pull_request.base.sha // empty' "$GITHUB_EVENT_PATH")
+
 # Extract owner and repo from GITHUB_REPOSITORY
 owner="${GITHUB_REPOSITORY%%/*}"
 repo="${GITHUB_REPOSITORY#*/}"
@@ -67,7 +74,9 @@ urlencode() { printf '%s' "$1" | jq -sRr @uri; }
 # Strip git ref prefix (e.g. "origin/main:path.yaml" -> "path.yaml", "HEAD:path.yaml" -> "path.yaml")
 base_path=$(echo "$base" | sed 's/.*://')
 rev_path=$(echo "$revision" | sed 's/.*://')
-free_review_url="https://www.oasdiff.com/review?owner=${owner}&repo=${repo}&base_sha=${GITHUB_BASE_REF}&rev_sha=${head_sha}&base_file=$(urlencode "$base_path")&rev_file=$(urlencode "$rev_path")"
+# Prefer the base SHA over the branch name so the link is commit-pinned.
+free_base_sha="${base_sha:-$GITHUB_BASE_REF}"
+free_review_url="https://www.oasdiff.com/review?owner=${owner}&repo=${repo}&base_sha=${free_base_sha}&rev_sha=${head_sha}&base_file=$(urlencode "$base_path")&rev_file=$(urlencode "$rev_path")"
 echo "::notice::📋 View API changes → ${free_review_url}"
 
 # Build the JSON payload
@@ -78,10 +87,11 @@ payload=$(jq -n \
     --argjson pr "$pr_number" \
     --arg sha "$head_sha" \
     --arg base_ref "$GITHUB_BASE_REF" \
+    --arg base_sha "$base_sha" \
     --arg base_file "$base" \
     --arg rev_file "$revision" \
     --argjson changes "$changes" \
-    '{github: {token: $token, owner: $owner, repo: $repo, pull_number: $pr, head_sha: $sha, base_ref: $base_ref}, base_file: $base_file, rev_file: $rev_file, changes: $changes}')
+    '{github: {token: $token, owner: $owner, repo: $repo, pull_number: $pr, head_sha: $sha, base_ref: $base_ref, base_sha: $base_sha}, base_file: $base_file, rev_file: $rev_file, changes: $changes}')
 
 # POST to oasdiff-service (requires token)
 if [ -z "$oasdiff_token" ]; then


### PR DESCRIPTION
## Summary

The pr-comment action now extracts `pull_request.base.sha` from the GitHub event payload and propagates it in two places:

1. **Free-review URL annotation** (`::notice::`): uses the base SHA instead of the branch name. The link is now commit-pinned and stays valid even if the base branch advances after the PR was opened.
2. **JSON payload to `oasdiff-service`**: gains a `github.base_sha` field alongside the existing `github.base_ref`. The service stores it on the report so the review page can show the exact base content oasdiff compared against, rather than chasing whatever the base branch happens to point at when the reviewer opens the page.

`base_ref` is preserved for backward compatibility with reports stored before this field existed, and for the rare case where `pull_request.base.sha` is empty in the event payload.

## Why

The review page's side-by-side viewer renders content fetched from `raw.githubusercontent.com/<owner>/<repo>/<ref>/<file>`. When `<ref>` is a branch name like `main`, the content can drift between when the PR was opened and when the reviewer opens it. Pinning to the base commit SHA fixes that.

## Test plan

- [ ] Trigger the action on a PR. Check the workflow log for the `::notice::` line — confirm the URL contains a 40-char SHA, not a branch name, in the `base_sha=` query parameter.
- [ ] Inspect the JSON payload submitted to oasdiff-service (visible in step output) — confirm it has a `github.base_sha` field with the same SHA.
- [ ] Open the resulting review page and confirm it still loads correctly (depends on oasdiff-service merging the companion PR that accepts the new field; until then, the field is ignored, no regression).