### PR TITLE
chore: bump README references to v0.0.42

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - run: git fetch --depth=1 origin ${{ github.base_ref }}
-      - uses: oasdiff/oasdiff-action/breaking@v0.0.41
+      - uses: oasdiff/oasdiff-action/breaking@v0.0.42
         with:
           base: 'origin/${{ github.base_ref }}:openapi.yaml'
           revision: 'HEAD:openapi.yaml'
@@ -49,7 +49,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - run: git fetch --depth=1 origin ${{ github.base_ref }}
-      - uses: oasdiff/oasdiff-action/breaking@v0.0.41
+      - uses: oasdiff/oasdiff-action/breaking@v0.0.42
         with:
           base: 'origin/${{ github.base_ref }}:openapi.yaml'
           revision: 'HEAD:openapi.yaml'
@@ -88,7 +88,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - run: git fetch --depth=1 origin ${{ github.base_ref }}
-      - uses: oasdiff/oasdiff-action/changelog@v0.0.41
+      - uses: oasdiff/oasdiff-action/changelog@v0.0.42
         with:
           base: 'origin/${{ github.base_ref }}:openapi.yaml'
           revision: 'HEAD:openapi.yaml'
@@ -126,7 +126,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - run: git fetch --depth=1 origin ${{ github.base_ref }}
-      - uses: oasdiff/oasdiff-action/diff@v0.0.41
+      - uses: oasdiff/oasdiff-action/diff@v0.0.42
         with:
           base: 'origin/${{ github.base_ref }}:openapi.yaml'
           revision: 'HEAD:openapi.yaml'
@@ -185,7 +185,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - run: git fetch --depth=1 origin ${{ github.base_ref }}
-      - uses: oasdiff/oasdiff-action/pr-comment@v0.0.41
+      - uses: oasdiff/oasdiff-action/pr-comment@v0.0.42
         with:
           base: 'origin/${{ github.base_ref }}:openapi.yaml'
           revision: 'HEAD:openapi.yaml'


### PR DESCRIPTION
Action-only release v0.0.42 was tagged via release-action.sh, which doesn't bump README references. This PR catches them up. Going forward, the release script will do this automatically.