### PR TITLE
feat(changelog): emit free review link when changes are found

### DIFF
--- a/changelog/Dockerfile
+++ b/changelog/Dockerfile
@@ -1,4 +1,5 @@
 FROM tufin/oasdiff:v1.15.0
+RUN apk add --no-cache jq
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/changelog/entrypoint.sh
+++ b/changelog/entrypoint.sh
@@ -99,6 +99,17 @@ fi
 
 if [ -n "$output" ] && ! echo "$output" | head -n 1 | grep -q "^No "; then
     write_output "$output"
+    # Emit upgrade notice pointing to the free review page
+    urlencode() { printf '%s' "$1" | jq -sRr @uri; }
+    base_path=$(echo "$base" | sed 's/.*://')
+    rev_path=$(echo "$revision" | sed 's/.*://')
+    owner="${GITHUB_REPOSITORY%%/*}"
+    repo="${GITHUB_REPOSITORY#*/}"
+    head_sha=$(jq -r '.pull_request.head.sha // empty' "$GITHUB_EVENT_PATH" 2>/dev/null || echo "")
+    if [ -z "$head_sha" ]; then head_sha="$GITHUB_SHA"; fi
+    free_review_url="https://www.oasdiff.com/review?owner=${owner}&repo=${repo}&base_sha=$(urlencode "$GITHUB_BASE_REF")&rev_sha=${head_sha}&base_file=$(urlencode "$base_path")&rev_file=$(urlencode "$rev_path")"
+    echo "::notice::📋 Review & approve these API changes → ${free_review_url}"
+    echo "### 📋 [Review & approve these API changes](${free_review_url})" >> "$GITHUB_STEP_SUMMARY"
 else
     write_output "No changelog changes"
 fi


### PR DESCRIPTION
## Summary

Mirrors the existing pattern in the [`breaking` action](https://github.com/oasdiff/oasdiff-action/blob/main/breaking/entrypoint.sh): when `oasdiff changelog` finds changes, emit a `::notice::` annotation and a `$GITHUB_STEP_SUMMARY` markdown link pointing at the free review page at oasdiff.com.

The wording matches the breaking action (`Review & approve these API changes`) because the changelog action surfaces all severities, and warn/err changes still need approval to clear the merge gate just like breaking ones.

## Test plan

- [ ] Run the action on a PR that introduces an API change and confirm a `::notice::` annotation appears with a link to `https://www.oasdiff.com/review?...`.
- [ ] Confirm the same link is rendered as a clickable markdown header in the GitHub Actions step summary.
- [ ] Run the action on a PR with no API changes and confirm no notice or step summary entry is emitted.
- [ ] Click the link and confirm it loads the free review page with the expected base/revision files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)