### PR TITLE
feat(pr-comment): handle 409 github_app_not_installed gracefully

### DIFF
--- a/pr-comment/entrypoint.sh
+++ b/pr-comment/entrypoint.sh
@@ -114,6 +114,26 @@ if [ "$http_code" -ge 200 ] && [ "$http_code" -lt 300 ]; then
     if [ -n "$report_url" ]; then
         echo "Review page: $report_url"
     fi
+elif [ "$http_code" = "409" ] && [ "$(echo "$body" | jq -r '.code // empty' 2>/dev/null)" = "github_app_not_installed" ]; then
+    # The service returns 409 with a structured JSON body when the customer's
+    # repo does not have the oasdiff GitHub App installed. Surface a clear,
+    # actionable error to the workflow log and step summary.
+    err_owner=$(echo "$body" | jq -r '.owner')
+    err_repo=$(echo "$body" | jq -r '.repo')
+    install_url=$(echo "$body" | jq -r '.install_url')
+    echo "::error title=oasdiff GitHub App not installed::Install the App at ${install_url} on ${err_owner}/${err_repo} and re-run this workflow."
+    {
+        echo "### ❌ oasdiff GitHub App not installed"
+        echo ""
+        echo "The oasdiff GitHub App is not installed on **${err_owner}/${err_repo}**, so this workflow cannot post a PR comment or set commit statuses."
+        echo ""
+        echo "**Fix:**"
+        echo ""
+        echo "1. Visit [${install_url}](${install_url})"
+        echo "2. Click **Install** and select the \`${err_owner}/${err_repo}\` repository"
+        echo "3. Re-run this workflow"
+    } >> "$GITHUB_STEP_SUMMARY"
+    exit 1
 else
     echo "ERROR: oasdiff-service returned HTTP $http_code" >&2
     echo "$body" >&2


### PR DESCRIPTION
## Summary

Pairs with [oasdiff-service PR #175](https://github.com/oasdiff/oasdiff-service/pull/175), which changes the App-not-installed response from HTTP 502 plain text to HTTP 409 with a structured JSON body.

When the service returns:

```
HTTP/1.1 409 Conflict
{ "code": "github_app_not_installed", "owner": ..., "repo": ..., "install_url": ... }
```

…the action now:

1. Emits a `::error::` workflow annotation with a title and the install URL — visible inline on the PR's checks tab.
2. Writes a markdown setup checklist to `$GITHUB_STEP_SUMMARY` — visible on the workflow run page — walking the customer through Install → select repo → re-run.
3. Exits non-zero so the workflow fails (the action couldn't do its job).

Falls back to the existing generic-error behavior for any other non-2xx response.

## Why this matters

Today's symptom: a customer signs up, sets up the action, opens a PR, gets a red X with a wall-of-log error. The fix is one click (install the App), but they have to dig through the workflow log to find the URL. After this change, the install URL is in a workflow annotation *and* the step summary — impossible to miss.

This complements (does not replace) a future pre-flight check in the setup wizard: even if pre-flight passes, the App can be uninstalled later, and this surfaces that gracefully.

## Test plan

- [ ] Once oasdiff-service PR #175 is deployed, run the action against a repo where the App is not installed. Verify:
  - [ ] The `::error::` annotation appears on the PR checks tab with title "oasdiff GitHub App not installed".
  - [ ] The workflow run summary shows the setup checklist with a clickable install link.
  - [ ] Exit code is non-zero (workflow fails red).
- [ ] Run against a repo *with* the App installed — no regression in the success path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
