### PR TITLE
docs: revert oasdiff.yaml configuration section pending move to .oasdiff.*

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ GitHub Actions for comparing OpenAPI specs and detecting breaking changes, based
   - [Check for breaking changes](#check-for-breaking-changes)
   - [Generate a changelog](#generate-a-changelog)
   - [Generate a diff report](#generate-a-diff-report)
-  - [Configuring with `oasdiff.yaml`](#configuring-with-oasdiffyaml)
 - [Spec paths](#spec-paths)
 - [Pro: Rich PR comment](#pro-rich-pr-comment)
 
@@ -155,25 +154,6 @@ jobs:
 | `composed` | `false` | Run in composed mode | `true`, `false` |
 | `flatten-allof` | `false` | Merge allOf subschemas into a single schema before diff | `true`, `false` |
 | `output-to-file` | `''` | Write output to this file path instead of stdout | file path |
-
-### Configuring with `oasdiff.yaml`
-
-All free actions inherit the CLI's config-file support. Drop an `oasdiff.yaml` at your repo root and the actions pick it up automatically — no extra wiring needed:
-
-```yaml
-# oasdiff.yaml at your repo root
-exclude-elements:
-  - endpoints
-flatten-allof: true
-deprecation-days-stable: 180
-fail-on: ERR
-```
-
-Any flag the oasdiff CLI supports works in the config file — see [CONFIG-FILES.md](https://github.com/oasdiff/oasdiff/blob/main/docs/CONFIG-FILES.md) for the full reference and supported file formats (`oasdiff.{json,yaml,yml,toml,hcl}`).
-
-Action `inputs:` take precedence over config-file values, so you can use the file for shared defaults across workflows and override per-workflow via inputs.
-
-> **Limitation**: action inputs can only turn a boolean flag *on*, not *off*. If your `oasdiff.yaml` sets `composed: true`, passing `composed: 'false'` to the action has no effect — to disable it for a specific workflow run, edit the YAML.
 
 ---
 


### PR DESCRIPTION
## Summary

Reverts the "Configuring with `oasdiff.yaml`" subsection added in #110/#111. The documented filename (`oasdiff.yaml` at repo root) is unconventional for a CI/lint tool — most tools in this category use a dotfile (`.eslintrc`, `.prettierrc`, `.golangci.yml`, `.yamllint`, `.flake8`, `.markdownlint.json`).

Pulling the docs section now so customers don't adopt the unconventional path during the brief window we recommended it. The CLI's config-file lookup will move to `.oasdiff.*` in a follow-up; documentation will return at that point with the right path.

## What stays

- The Contents (TOC) infrastructure added in #111 — only its line for the removed section is dropped.
- The boolean-limitation wording fix from #111 (no longer relevant since the section is gone).
- All other action subsections (breaking, changelog, diff) and Pro: Rich PR comment.

## Companion reverts

- `oasdiff/w3#???` — same-shape revert of `/docs/github-action` page.
- `oasdiff/oasdiff#???` — drop the cross-link added to `CONFIG-FILES.md`.

## Test plan

- [ ] Read the rendered README on GitHub
- [ ] Confirm the TOC still scrolls to the right sections
- [ ] Confirm the Free actions block ends after the diff action and goes straight to "Spec paths"
