### PR TITLE
actions: pin /review URLs to the immutable base commit SHA

### DIFF
--- a/breaking/entrypoint.sh
+++ b/breaking/entrypoint.sh
@@ -115,7 +115,15 @@ if [ -n "$breaking_changes" ] && ! echo "$breaking_changes" | head -n 1 | grep -
     repo="${GITHUB_REPOSITORY#*/}"
     head_sha=$(jq -r '.pull_request.head.sha // empty' "$GITHUB_EVENT_PATH" 2>/dev/null || echo "")
     if [ -z "$head_sha" ]; then head_sha="$GITHUB_SHA"; fi
-    free_review_url="https://www.oasdiff.com/review?owner=${owner}&repo=${repo}&base_sha=$(urlencode "$GITHUB_BASE_REF")&rev_sha=${head_sha}&base_file=$(urlencode "$base_path")&rev_file=$(urlencode "$rev_path")"
+    # base_sha must be an immutable commit SHA, not the branch name. Using
+    # $GITHUB_BASE_REF (the branch) makes the URL decay whenever the branch
+    # advances past the file's commit — e.g. someone merges a rename of the
+    # spec file and every previously-emitted /review URL starts 404'ing
+    # because raw.githubusercontent.com now resolves the branch to a newer
+    # commit where the file lives at a different path.
+    base_sha=$(jq -r '.pull_request.base.sha // empty' "$GITHUB_EVENT_PATH" 2>/dev/null || echo "")
+    if [ -z "$base_sha" ]; then base_sha=$(git rev-parse "origin/$GITHUB_BASE_REF" 2>/dev/null || echo "$GITHUB_BASE_REF"); fi
+    free_review_url="https://www.oasdiff.com/review?owner=${owner}&repo=${repo}&base_sha=$(urlencode "$base_sha")&rev_sha=${head_sha}&base_file=$(urlencode "$base_path")&rev_file=$(urlencode "$rev_path")"
     echo "::notice::📋 Review & approve these breaking changes → ${free_review_url}"
     echo "### 📋 [Review & approve these breaking changes](${free_review_url})" >> "$GITHUB_STEP_SUMMARY"
 else

--- a/changelog/entrypoint.sh
+++ b/changelog/entrypoint.sh
@@ -107,7 +107,13 @@ if [ -n "$output" ] && ! echo "$output" | head -n 1 | grep -q "^No "; then
     repo="${GITHUB_REPOSITORY#*/}"
     head_sha=$(jq -r '.pull_request.head.sha // empty' "$GITHUB_EVENT_PATH" 2>/dev/null || echo "")
     if [ -z "$head_sha" ]; then head_sha="$GITHUB_SHA"; fi
-    free_review_url="https://www.oasdiff.com/review?owner=${owner}&repo=${repo}&base_sha=$(urlencode "$GITHUB_BASE_REF")&rev_sha=${head_sha}&base_file=$(urlencode "$base_path")&rev_file=$(urlencode "$rev_path")"
+    # base_sha must be an immutable commit SHA, not the branch name. Using
+    # $GITHUB_BASE_REF (the branch) makes the URL decay whenever the branch
+    # advances past the file's commit. See breaking/entrypoint.sh for the
+    # full rationale.
+    base_sha=$(jq -r '.pull_request.base.sha // empty' "$GITHUB_EVENT_PATH" 2>/dev/null || echo "")
+    if [ -z "$base_sha" ]; then base_sha=$(git rev-parse "origin/$GITHUB_BASE_REF" 2>/dev/null || echo "$GITHUB_BASE_REF"); fi
+    free_review_url="https://www.oasdiff.com/review?owner=${owner}&repo=${repo}&base_sha=$(urlencode "$base_sha")&rev_sha=${head_sha}&base_file=$(urlencode "$base_path")&rev_file=$(urlencode "$rev_path")"
     echo "::notice::📋 Review & approve these API changes → ${free_review_url}"
     echo "### 📋 [Review & approve these API changes](${free_review_url})" >> "$GITHUB_STEP_SUMMARY"
 else

--- a/pr-comment/entrypoint.sh
+++ b/pr-comment/entrypoint.sh
@@ -81,8 +81,16 @@ urlencode() { printf '%s' "$1" | jq -sRr @uri; }
 base_path=$(echo "$base" | sed 's/.*://')
 rev_path=$(echo "$revision" | sed 's/.*://')
 # Prefer the base SHA over the branch name so the link is commit-pinned.
-free_base_sha="${base_sha:-$GITHUB_BASE_REF}"
-free_review_url="https://www.oasdiff.com/review?owner=${owner}&repo=${repo}&base_sha=${free_base_sha}&rev_sha=${head_sha}&base_file=$(urlencode "$base_path")&rev_file=$(urlencode "$rev_path")"
+# Fall back through `git rev-parse origin/<branch>` before resorting to
+# the branch name itself, so push-event triggers (no pull_request payload)
+# also get an immutable SHA in the URL whenever the base branch was
+# fetched into the workspace.
+if [ -n "$base_sha" ]; then
+    free_base_sha="$base_sha"
+else
+    free_base_sha=$(git rev-parse "origin/$GITHUB_BASE_REF" 2>/dev/null || echo "$GITHUB_BASE_REF")
+fi
+free_review_url="https://www.oasdiff.com/review?owner=${owner}&repo=${repo}&base_sha=$(urlencode "$free_base_sha")&rev_sha=${head_sha}&base_file=$(urlencode "$base_path")&rev_file=$(urlencode "$rev_path")"
 echo "::notice::📋 View API changes → ${free_review_url}"
 
 # Build the JSON payload


### PR DESCRIPTION
## Summary

The free `/review` URL emitted by `breaking`, `changelog`, and `pr-comment` used `$GITHUB_BASE_REF` (the branch name, e.g. `main`) in the `base_sha` query parameter. That's mutable — once the base branch advances past the commit the action ran against, every previously-emitted URL silently breaks. `raw.githubusercontent.com` resolves the branch to whatever HEAD is *now*, not what HEAD was when CI ran. The `rev_sha` parameter was already pinned to the immutable head commit; `base_sha` was not.

Concrete failure mode: a workflow runs, emits a `::notice::` link with `base_sha=main&base_file=backend/openapi.json`. Later, another PR merges a rename of that file. The original `::notice::` link now 404s on the base side, and the visitor can't tell whether the cause is a permissions problem or a moved file. So they chase the wrong fix.

## Fix

Three-tier fallback for `base_sha` in all three URL-emitting entrypoints:

1. `pull_request.base.sha` from `$GITHUB_EVENT_PATH` (canonical for `pull_request` triggers)
2. `git rev-parse origin/$GITHUB_BASE_REF` (push triggers that have fetched the base branch)
3. `$GITHUB_BASE_REF` (ultimate fallback — today's behavior)

`pr-comment` already used `#1` with `#3` as fallback; this PR adds `#2` to its chain. `breaking` and `changelog` gain the whole chain. `head_sha` extraction is unchanged.

## Test plan

- [x] `bash -n` syntax check on all three entrypoints
- [ ] Existing integration tests pass (the test workflow exercises the actions end-to-end)
- [ ] After merge, watch a real PR run and confirm the emitted `::notice::` link contains a 40-char SHA in the `base_sha=` position, not a branch name

## Backward compatibility

Strict superset of today's contract. Worst case (no `pull_request.base.sha` available, `git rev-parse` fails) falls back to `$GITHUB_BASE_REF`, which is today's behavior. URLs already in the wild keep working at the same URLs they pointed at before; the change affects only newly-emitted URLs from this version forward.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)