### PR TITLE
docs: fix CI badge after the test.yaml split

### DIFF
--- a/.github/workflows/test-breaking.yaml
+++ b/.github/workflows/test-breaking.yaml
@@ -1,4 +1,4 @@
-name: 'Test oasdiff breaking action'
+name: breaking
 on:
   pull_request:
   push:

--- a/.github/workflows/test-changelog.yaml
+++ b/.github/workflows/test-changelog.yaml
@@ -1,4 +1,4 @@
-name: 'Test oasdiff changelog action'
+name: changelog
 on:
   pull_request:
   push:

--- a/.github/workflows/test-diff.yaml
+++ b/.github/workflows/test-diff.yaml
@@ -1,4 +1,4 @@
-name: 'Test oasdiff diff action'
+name: diff
 on:
   pull_request:
   push:

--- a/.github/workflows/test-pr-comment.yaml
+++ b/.github/workflows/test-pr-comment.yaml
@@ -1,4 +1,4 @@
-name: 'Test oasdiff pr-comment action'
+name: pr-comment
 on:
   pull_request:
   push:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # oasdiff-action
-[![CI](https://github.com/oasdiff/oasdiff-action/actions/workflows/test.yaml/badge.svg)](https://github.com/oasdiff/oasdiff-action/actions)
+[![breaking](https://github.com/oasdiff/oasdiff-action/actions/workflows/test-breaking.yaml/badge.svg)](https://github.com/oasdiff/oasdiff-action/actions/workflows/test-breaking.yaml)
+[![changelog](https://github.com/oasdiff/oasdiff-action/actions/workflows/test-changelog.yaml/badge.svg)](https://github.com/oasdiff/oasdiff-action/actions/workflows/test-changelog.yaml)
+[![diff](https://github.com/oasdiff/oasdiff-action/actions/workflows/test-diff.yaml/badge.svg)](https://github.com/oasdiff/oasdiff-action/actions/workflows/test-diff.yaml)
+[![pr-comment](https://github.com/oasdiff/oasdiff-action/actions/workflows/test-pr-comment.yaml/badge.svg)](https://github.com/oasdiff/oasdiff-action/actions/workflows/test-pr-comment.yaml)
 
 GitHub Actions for comparing OpenAPI specs and detecting breaking changes, based on [oasdiff](https://github.com/oasdiff/oasdiff).
 


### PR DESCRIPTION
## Summary

#121 split `test.yaml` into four per-action workflows but the README still pointed its single badge at `test.yaml`, which no longer exists (the badge now 404s on `main`).

- Replace the single badge with one per workflow: `breaking`, `changelog`, `diff`, `pr-comment`.
- Shorten each workflow `name:` so the rendered badge labels (and the Actions tab) read cleanly. The badge label comes from the workflow name, not the markdown alt text.

This is a follow-up to #121 (the badge change was pushed to that branch after it had already merged, so it never reached `main`).

## Test plan

- [x] `badge.svg` for all four workflows returns HTTP 200 on `main`
- [x] Each workflow still parses as valid YAML