### PR TITLE
Step Summary: include CLI command as a copyable code block (CLI Local Review Phase 1, step 5 of 5)

### DIFF
--- a/breaking/entrypoint.sh
+++ b/breaking/entrypoint.sh
@@ -134,7 +134,22 @@ if [ -n "$breaking_changes" ] && ! echo "$breaking_changes" | head -n 1 | grep -
     if [ -z "$base_sha" ]; then base_sha=$(git rev-parse "origin/$GITHUB_BASE_REF" 2>/dev/null || echo "$GITHUB_BASE_REF"); fi
     free_review_url="https://www.oasdiff.com/review?owner=${owner}&repo=${repo}&base_sha=$(urlencode "$base_sha")&rev_sha=${head_sha}&base_file=$(urlencode "$base_path")&rev_file=$(urlencode "$rev_path")"
     echo "::notice::📋 Review & approve these breaking changes → ${free_review_url}"
-    echo "### 📋 [Review & approve these breaking changes](${free_review_url})" >> "$GITHUB_STEP_SUMMARY"
+    # The Step Summary surfaces both the link (for visitors who'd rather use
+    # the web UI) and the CLI command itself (for visitors who recognize it
+    # and want to skip the instruction-page detour). GitHub renders the
+    # fenced code block with a built-in copy button, so the one-step path
+    # for the familiar-visitor cohort is: scroll to the Checks tab, click
+    # copy on the command, paste into a terminal in the local clone, run.
+    # See enterprise/docs/cli-local-review.md (Phase 1, step 5).
+    {
+        echo "### 📋 [Review & approve these breaking changes](${free_review_url})"
+        echo ""
+        echo "Or run locally in your clone of \`${repo}\`:"
+        echo ""
+        echo '```bash'
+        echo "oasdiff breaking ${base_sha}:${base_path} ${head_sha}:${rev_path} --open"
+        echo '```'
+    } >> "$GITHUB_STEP_SUMMARY"
 else
     write_output "No breaking changes"
 fi

--- a/changelog/entrypoint.sh
+++ b/changelog/entrypoint.sh
@@ -125,7 +125,20 @@ if [ -n "$output" ] && ! echo "$output" | head -n 1 | grep -q "^No "; then
     if [ -z "$base_sha" ]; then base_sha=$(git rev-parse "origin/$GITHUB_BASE_REF" 2>/dev/null || echo "$GITHUB_BASE_REF"); fi
     free_review_url="https://www.oasdiff.com/review?owner=${owner}&repo=${repo}&base_sha=$(urlencode "$base_sha")&rev_sha=${head_sha}&base_file=$(urlencode "$base_path")&rev_file=$(urlencode "$rev_path")"
     echo "::notice::📋 Review & approve these API changes → ${free_review_url}"
-    echo "### 📋 [Review & approve these API changes](${free_review_url})" >> "$GITHUB_STEP_SUMMARY"
+    # The Step Summary surfaces both the link (for visitors who'd rather use
+    # the web UI) and the CLI command itself (for visitors who recognize it
+    # and want to skip the instruction-page detour). GitHub renders the
+    # fenced code block with a built-in copy button. See
+    # enterprise/docs/cli-local-review.md (Phase 1, step 5).
+    {
+        echo "### 📋 [Review & approve these API changes](${free_review_url})"
+        echo ""
+        echo "Or run locally in your clone of \`${repo}\`:"
+        echo ""
+        echo '```bash'
+        echo "oasdiff changelog ${base_sha}:${base_path} ${head_sha}:${rev_path} --open"
+        echo '```'
+    } >> "$GITHUB_STEP_SUMMARY"
 else
     write_output "No changelog changes"
 fi


### PR DESCRIPTION
Final step of CLI Local Review Phase 1. The free `breaking` and `changelog` actions' Step Summary already emit a clickable link to `/review?owner=...`. This PR adds the CLI command itself as a fenced code block alongside the link, so visitors who recognize the command can copy it directly from the PR's Checks tab and bypass the instruction-page detour.

## What changes

Before (the existing emit):
```
### 📋 [Review & approve these breaking changes](https://www.oasdiff.com/review?owner=...)
```

After:
```
### 📋 [Review & approve these breaking changes](https://www.oasdiff.com/review?owner=...)

Or run locally in your clone of `<repo>`:

```bash
oasdiff breaking <base_sha>:<base_file> <head_sha>:<rev_file> --open
```
```

GitHub renders the fenced code block with a built-in copy button. The familiar-visitor cohort one-steps the flow; the unfamiliar-visitor cohort still has the link and lands on the instruction page (w3 #245), which hands them the same pre-filled command with explanatory copy.

Same change for the `changelog` action (`oasdiff changelog` instead of `oasdiff breaking`).

## Backward compat

Customers running pinned older versions (e.g. `oasdiff/oasdiff-action/breaking@v0.0.48`) see the old Step Summary, which still works — the link still resolves to the instruction page after w3 #245 ships, and that page hands them the command they would have seen here. No customer is broken by skipping this upgrade.

## Test plan

- [ ] Trigger the breaking action on a test PR with a real breaking change. Check the Step Summary: link + code block both rendered, code block has GitHub's copy button.
- [ ] Copy the command and run in a local clone. Confirm it generates a working `/review/local/[id]` URL.
- [ ] Same for the changelog action.

## Depends on

oasdiff #955 (the `--open` flag the emitted command depends on) — recommended sequence: ship #955 first, then this PR.