### PR TITLE
bump: oasdiff v1.18.0

### DIFF
--- a/breaking/Dockerfile
+++ b/breaking/Dockerfile
@@ -1,4 +1,4 @@
-FROM tufin/oasdiff:v1.17.0
+FROM tufin/oasdiff:v1.18.0
 RUN apk add --no-cache jq
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh

--- a/changelog/Dockerfile
+++ b/changelog/Dockerfile
@@ -1,4 +1,4 @@
-FROM tufin/oasdiff:v1.17.0
+FROM tufin/oasdiff:v1.18.0
 RUN apk add --no-cache jq
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh

--- a/diff/Dockerfile
+++ b/diff/Dockerfile
@@ -1,4 +1,4 @@
-FROM tufin/oasdiff:v1.17.0
+FROM tufin/oasdiff:v1.18.0
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/pr-comment/Dockerfile
+++ b/pr-comment/Dockerfile
@@ -1,4 +1,4 @@
-FROM tufin/oasdiff:v1.17.0
+FROM tufin/oasdiff:v1.18.0
 RUN apk add --no-cache curl jq
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh

--- a/validate/Dockerfile
+++ b/validate/Dockerfile
@@ -1,4 +1,4 @@
-FROM tufin/oasdiff:v1.17.0
+FROM tufin/oasdiff:v1.18.0
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Bumps each action's Dockerfile FROM from `tufin/oasdiff:v1.17.0` to `tufin/oasdiff:v1.18.0`. Customers pin `oasdiff/oasdiff-action/*@<tag>` so the image pin lives in the action repo, not in customer workflows.

## What v1.18.0 brings

- **#964** Annotation-only `allOf` additions are no longer reported as breaking. Eight new INFO check IDs for the audit trail. Closes the false positive that fails CI gates on documentation edits.
- **#958** `oasdiff breaking --open` now filters the rendered page to ERR/WARN findings, matching the visitor's terminal output.
- **#969** Spanish, Portuguese, and Russian translations for the `exclusiveMinimum` / `exclusiveMaximum` families.
- **#960–#963 + #970–#972** Internal walker migration completes. No behaviour change.

Full release notes: https://github.com/oasdiff/oasdiff/releases/tag/v1.18.0