### PR TITLE
actions: surface genuine oasdiff errors as PR annotations

### DIFF
--- a/.github/workflows/test-error-annotation.yaml
+++ b/.github/workflows/test-error-annotation.yaml
@@ -5,17 +5,17 @@ on:
 jobs:
   entrypoint_error_annotation:
     runs-on: ubuntu-latest
-    name: Entrypoints surface genuine errors as annotations, not fail-on
+    name: Entrypoints surface genuine errors as annotations, not success/fail-on
     steps:
       - name: checkout
         uses: actions/checkout@v6
-      - name: Exercise entrypoints with a stubbed oasdiff
+      - name: Exercise every entrypoint with a stubbed oasdiff
         run: |
           set -eu
 
-          # Stub oasdiff: write $STUB_STDERR to stderr (if set) and exit
-          # $STUB_CODE. Lets us drive the entrypoints' exit-code handling
-          # deterministically without a real spec or network.
+          # Stub oasdiff: write $STUB_STDERR to stderr (if set), produce no
+          # stdout, and exit $STUB_CODE. Lets us drive each entrypoint's
+          # exit-code handling deterministically — no real spec, no network.
           mkdir -p /tmp/bin
           cat > /tmp/bin/oasdiff <<'STUB'
           #!/bin/sh
@@ -24,39 +24,43 @@ jobs:
           STUB
           chmod +x /tmp/bin/oasdiff
           export PATH="/tmp/bin:$PATH"
-          export GITHUB_OUTPUT=/tmp/gh_output
-          export GITHUB_STEP_SUMMARY=/tmp/gh_summary
-          export GITHUB_REPOSITORY=o/r GITHUB_SHA=deadbeef
+          export GITHUB_OUTPUT=/tmp/gh_output GITHUB_STEP_SUMMARY=/tmp/gh_summary
+          export GITHUB_REPOSITORY=o/r GITHUB_SHA=deadbeef GITHUB_REF=refs/pull/1/merge
+          echo '{}' > /tmp/event.json; export GITHUB_EVENT_PATH=/tmp/event.json
 
           fail() { echo "FAIL: $1" >&2; exit 1; }
 
-          # $1=entrypoint $2=exit-code $3=stderr ; echoes the entrypoint's stdout.
-          # Trailing args after $3 are the positional inputs for that entrypoint.
-          run() {
-            ep="$1"; code="$2"; err="$3"; shift 3
+          # invoke <exit-code> <stderr> <command> -> prints the entrypoint's stdout.
+          # pr-comment gets an empty oasdiff-token so it skips the network POST.
+          invoke() {
+            export STUB_CODE="$1" STUB_STDERR="$2"; cmd="$3"
             : > "$GITHUB_OUTPUT"; : > "$GITHUB_STEP_SUMMARY"
-            STUB_CODE="$code" STUB_STDERR="$err" sh "$ep" "$@" 2>/dev/null || true
+            case "$cmd" in
+              breaking)   sh breaking/entrypoint.sh   base.yaml rev.yaml "" "" "" "" "" "" "" "" "" "" "" "" "false" ;;
+              changelog)  sh changelog/entrypoint.sh  base.yaml rev.yaml "" "" "" "" "" "" "" "" "" "" "" "" "false" ;;
+              diff)       sh diff/entrypoint.sh       base.yaml rev.yaml "" "" "" "" "" "" "" "false" ;;
+              pr-comment) sh pr-comment/entrypoint.sh base.yaml rev.yaml "" "" "" "" "" "" "false" ;;
+              validate)   sh validate/entrypoint.sh   spec.yaml "" "false" ;;
+            esac
           }
 
-          # validate (standalone shape, shared by breaking/diff): spec, fail-on, allow-external-refs
-          v() { run validate/entrypoint.sh "$1" "$2" valid.yaml "" "false"; }
-          # changelog (early-exit shape, shared by pr-comment): 15 positional inputs
-          c() { run changelog/entrypoint.sh "$1" "$2" base.yaml rev.yaml "" "" "" "" "" "" "" "" "" "" "" "" "false"; }
+          for cmd in breaking changelog diff pr-comment validate; do
+            # success (exit 0): no ::error:: annotation
+            out=$(invoke 0 "" "$cmd" 2>/dev/null || true)
+            echo "$out" | grep -q '::error::' && fail "$cmd: success (exit 0) must not emit ::error::"
 
-          # --- genuine load error (exit 102) -> generic ::error:: annotation ---
-          echo "$(v 102 'Error: failed to load spec from "x.yaml": no such file')" | grep -q '::error::' \
-            || fail "validate: exit 102 should emit a ::error:: annotation"
-          echo "$(c 102 'Error: failed to load spec from "x.yaml": no such file')" | grep -q '::error::' \
-            || fail "changelog: exit 102 should emit a ::error:: annotation"
+            # genuine error (exit 102): ::error:: annotation surfaced
+            out=$(invoke 102 'Error: failed to load spec from "x.yaml": no such file' "$cmd" 2>/dev/null || true)
+            echo "$out" | grep -q '::error::' || fail "$cmd: exit 102 must emit a ::error:: annotation"
 
-          # --- disallowed external ref (exit 123) -> the allow-external-refs remedy ---
-          echo "$(v 123 'Error: external $ref not allowed: https://evil')" | grep -q "allow-external-refs: true" \
-            || fail "validate: exit 123 should emit the allow-external-refs remedy"
-          echo "$(c 123 'Error: external $ref not allowed: https://evil')" | grep -q "allow-external-refs: true" \
-            || fail "changelog: exit 123 should emit the allow-external-refs remedy"
+            # disallowed external ref (exit 123): the allow-external-refs remedy
+            out=$(invoke 123 'Error: external $ref not allowed: https://evil' "$cmd" 2>/dev/null || true)
+            echo "$out" | grep -q 'allow-external-refs: true' || fail "$cmd: exit 123 must emit the allow-external-refs remedy"
 
-          # --- fail-on / changes-found (exit 1, no stderr) -> NO ::error:: annotation ---
-          if echo "$(v 1 '')" | grep -q '::error::'; then fail "validate: exit 1 (fail-on) must not annotate"; fi
-          if echo "$(c 1 '')" | grep -q '::error::'; then fail "changelog: exit 1 (fail-on) must not annotate"; fi
+            # fail-on / changes-found (exit 1, no stderr): no ::error:: annotation
+            out=$(invoke 1 "" "$cmd" 2>/dev/null || true)
+            echo "$out" | grep -q '::error::' && fail "$cmd: exit 1 (fail-on) must not emit ::error::"
 
+            echo "ok: $cmd"
+          done
           echo "all error-annotation assertions passed"

--- a/.github/workflows/test-error-annotation.yaml
+++ b/.github/workflows/test-error-annotation.yaml
@@ -1,0 +1,62 @@
+name: error-annotation
+on:
+  pull_request:
+  push:
+jobs:
+  entrypoint_error_annotation:
+    runs-on: ubuntu-latest
+    name: Entrypoints surface genuine errors as annotations, not fail-on
+    steps:
+      - name: checkout
+        uses: actions/checkout@v6
+      - name: Exercise entrypoints with a stubbed oasdiff
+        run: |
+          set -eu
+
+          # Stub oasdiff: write $STUB_STDERR to stderr (if set) and exit
+          # $STUB_CODE. Lets us drive the entrypoints' exit-code handling
+          # deterministically without a real spec or network.
+          mkdir -p /tmp/bin
+          cat > /tmp/bin/oasdiff <<'STUB'
+          #!/bin/sh
+          [ -n "${STUB_STDERR:-}" ] && printf '%s\n' "$STUB_STDERR" >&2
+          exit "${STUB_CODE:-0}"
+          STUB
+          chmod +x /tmp/bin/oasdiff
+          export PATH="/tmp/bin:$PATH"
+          export GITHUB_OUTPUT=/tmp/gh_output
+          export GITHUB_STEP_SUMMARY=/tmp/gh_summary
+          export GITHUB_REPOSITORY=o/r GITHUB_SHA=deadbeef
+
+          fail() { echo "FAIL: $1" >&2; exit 1; }
+
+          # $1=entrypoint $2=exit-code $3=stderr ; echoes the entrypoint's stdout.
+          # Trailing args after $3 are the positional inputs for that entrypoint.
+          run() {
+            ep="$1"; code="$2"; err="$3"; shift 3
+            : > "$GITHUB_OUTPUT"; : > "$GITHUB_STEP_SUMMARY"
+            STUB_CODE="$code" STUB_STDERR="$err" sh "$ep" "$@" 2>/dev/null || true
+          }
+
+          # validate (standalone shape, shared by breaking/diff): spec, fail-on, allow-external-refs
+          v() { run validate/entrypoint.sh "$1" "$2" valid.yaml "" "false"; }
+          # changelog (early-exit shape, shared by pr-comment): 15 positional inputs
+          c() { run changelog/entrypoint.sh "$1" "$2" base.yaml rev.yaml "" "" "" "" "" "" "" "" "" "" "" "" "false"; }
+
+          # --- genuine load error (exit 102) -> generic ::error:: annotation ---
+          echo "$(v 102 'Error: failed to load spec from "x.yaml": no such file')" | grep -q '::error::' \
+            || fail "validate: exit 102 should emit a ::error:: annotation"
+          echo "$(c 102 'Error: failed to load spec from "x.yaml": no such file')" | grep -q '::error::' \
+            || fail "changelog: exit 102 should emit a ::error:: annotation"
+
+          # --- disallowed external ref (exit 123) -> the allow-external-refs remedy ---
+          echo "$(v 123 'Error: external $ref not allowed: https://evil')" | grep -q "allow-external-refs: true" \
+            || fail "validate: exit 123 should emit the allow-external-refs remedy"
+          echo "$(c 123 'Error: external $ref not allowed: https://evil')" | grep -q "allow-external-refs: true" \
+            || fail "changelog: exit 123 should emit the allow-external-refs remedy"
+
+          # --- fail-on / changes-found (exit 1, no stderr) -> NO ::error:: annotation ---
+          if echo "$(v 1 '')" | grep -q '::error::'; then fail "validate: exit 1 (fail-on) must not annotate"; fi
+          if echo "$(c 1 '')" | grep -q '::error::'; then fail "changelog: exit 1 (fail-on) must not annotate"; fi
+
+          echo "all error-annotation assertions passed"

--- a/breaking/entrypoint.sh
+++ b/breaking/entrypoint.sh
@@ -95,6 +95,12 @@ exit_code=0
 _err=$(mktemp)
 breaking_changes=$(oasdiff breaking "$base" "$revision" $flags $fail_on_flag 2>"$_err") || exit_code=$?
 [ -s "$_err" ] && cat "$_err" >&2
+# Promote a genuine oasdiff failure to a Checks-tab annotation. Exit 0 is
+# success and exit 1 is the intended "breaking changes found" / fail-on result;
+# only codes >=2 (load/parse/etc.) are real errors worth surfacing here.
+if [ "$exit_code" -ge 2 ] && [ -s "$_err" ]; then
+    echo "::error::$(tr '\n' ' ' < "$_err")"
+fi
 # Exit code 123 = oasdiff refused a disallowed external $ref (stable contract,
 # not message text). Surface the action-specific remedy.
 if [ "$exit_code" -eq 123 ]; then

--- a/changelog/entrypoint.sh
+++ b/changelog/entrypoint.sh
@@ -104,6 +104,11 @@ else
 fi
 if [ "$exit_code" -ne 0 ]; then
     [ -s "$_err" ] && cat "$_err" >&2
+    # Promote a genuine failure to a Checks-tab annotation. Exit 1 is the
+    # intended fail-on result (not an error); only codes >=2 are real errors.
+    if [ "$exit_code" -ge 2 ] && [ -s "$_err" ]; then
+        echo "::error::$(tr '\n' ' ' < "$_err")"
+    fi
     # Exit code 123 = oasdiff refused a disallowed external $ref (stable
     # contract, not message text). Surface the action-specific remedy.
     if [ "$exit_code" -eq 123 ]; then

--- a/diff/entrypoint.sh
+++ b/diff/entrypoint.sh
@@ -88,6 +88,12 @@ else
     output=$(oasdiff diff "$base" "$revision" 2>"$_err") || exit_code=$?
 fi
 [ -s "$_err" ] && cat "$_err" >&2
+# Promote a genuine oasdiff failure to a Checks-tab annotation. Exit 0 is
+# success and exit 1 is the intended fail-on-diff result; only codes >=2
+# (load/parse/etc.) are real errors worth surfacing here.
+if [ "$exit_code" -ge 2 ] && [ -s "$_err" ]; then
+    echo "::error::$(tr '\n' ' ' < "$_err")"
+fi
 # Exit code 123 = oasdiff refused a disallowed external $ref (stable contract,
 # not message text). Surface the action-specific remedy.
 if [ "$exit_code" -eq 123 ]; then

--- a/pr-comment/entrypoint.sh
+++ b/pr-comment/entrypoint.sh
@@ -46,6 +46,11 @@ _err=$(mktemp)
 changelog=$(oasdiff changelog "$base" "$revision" --format json $flags 2>"$_err") || oasdiff_exit=$?
 if [ "$oasdiff_exit" -ne 0 ] && [ -z "$changelog" ]; then
     [ -s "$_err" ] && cat "$_err" >&2
+    # Promote a genuine failure to a Checks-tab annotation. Exit 1 is the
+    # intended fail-on result (not an error); only codes >=2 are real errors.
+    if [ "$oasdiff_exit" -ge 2 ] && [ -s "$_err" ]; then
+        echo "::error::$(tr '\n' ' ' < "$_err")"
+    fi
     # Exit code 123 = oasdiff refused a disallowed external $ref (stable
     # contract, not message text). Surface the action-specific remedy.
     if [ "$oasdiff_exit" -eq 123 ]; then

--- a/validate/entrypoint.sh
+++ b/validate/entrypoint.sh
@@ -35,6 +35,12 @@ exit_code=0
 _err=$(mktemp)
 oasdiff validate $flags --format githubactions "$spec" 2>"$_err" || exit_code=$?
 [ -s "$_err" ] && cat "$_err" >&2
+# Promote a genuine oasdiff failure to a Checks-tab annotation. Exit 0 is
+# success and exit 1 is the intended fail-on result; only codes >=2
+# (load/parse/etc.) are real errors worth surfacing here.
+if [ "$exit_code" -ge 2 ] && [ -s "$_err" ]; then
+    echo "::error::$(tr '\n' ' ' < "$_err")"
+fi
 # Exit code 123 = oasdiff refused a disallowed external $ref (stable contract,
 # not message text). Surface the action-specific remedy.
 if [ "$exit_code" -eq 123 ]; then


### PR DESCRIPTION
Follow-up to #128. Makes a failed oasdiff invocation visible **on the PR's Checks tab**, not just buried in the raw step log.

## What

Each entrypoint (`breaking`, `changelog`, `diff`, `pr-comment`, `validate`) now promotes a genuine oasdiff failure to a GitHub `::error::` annotation (in addition to keeping the raw stderr in the log).

Gated on **exit code `>= 2`**, not `!= 0`:
- `0` = success
- `1` = the *intended* fail-on / changes-found result — **not** an error, so a normal "breaking changes found" run is never mislabeled
- `>= 2` = a genuine error (load/parse/etc.) → surfaced

The disallowed-external-ref remedy (exit `123`, from #128) is layered on top, so that case gets both the raw message and the actionable "set `allow-external-refs: true`" hint.

## Test

New `test-error-annotation.yaml` drives the `validate` (standalone shape) and `changelog` (early-exit shape) entrypoints with a **stubbed oasdiff** at exit `102` / `123` / `1`, asserting:
- `102` → a `::error::` annotation is emitted
- `123` → the `allow-external-refs: true` remedy is emitted
- `1` → **no** annotation (fail-on is not an error)

This is the only way to assert annotation presence/absence (it isn't visible via step `outcome`/`outputs`). Verified locally: all six assertions pass.

Intended to land before the `v0.0.51` action release so that release carries the full error-UX change.