### PR TITLE
pr-comment: surface repo-limit (402) as a warning, not a raw error

### DIFF
--- a/.github/workflows/test-pr-comment.yaml
+++ b/.github/workflows/test-pr-comment.yaml
@@ -393,3 +393,73 @@ jobs:
             echo "notice line: $notice" >&2
             exit 1
           fi
+
+  pr_comment_repo_limit_warns_without_failing:
+    runs-on: ubuntu-latest
+    name: Test pr-comment surfaces a repo-limit 402 as a warning without failing
+    # When the service returns 402 repo_limit_reached (this PR's repo is beyond
+    # the tenant's plan cap), the action should surface a warning annotation +
+    # step summary with the upgrade link but NOT fail the workflow (exit 0) -- a
+    # billing limit shouldn't break the customer's merge gate. Guards against
+    # regressing to the generic non-2xx branch, which dumps raw JSON and exits 1.
+    steps:
+      - uses: actions/checkout@v6
+      - name: Stub oasdiff + curl (402), run entrypoint with a fake token
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/stub /tmp/run
+
+          cat > /tmp/stub/oasdiff <<'STUB'
+          #!/bin/sh
+          printf '[{"id":"c1","text":"removed endpoint","level":3}]'
+          STUB
+          chmod +x /tmp/stub/oasdiff
+
+          # Stub curl: ignore the POST body, emit the 402 repo_limit_reached
+          # response (body, newline, status code) the entrypoint parses.
+          cat > /tmp/stub/curl <<'STUB'
+          #!/bin/sh
+          cat >/dev/null
+          printf '{"code":"repo_limit_reached","message":"Your oasdiff plan covers 5 repositories. acme/widgets is a new repository beyond that limit — upgrade at https://www.oasdiff.com/pricing to add it.","owner":"acme","repo":"widgets","max_repos":5,"upgrade_url":"https://www.oasdiff.com/pricing"}\n402\n'
+          STUB
+          chmod +x /tmp/stub/curl
+
+          export GITHUB_REF=refs/pull/123/merge
+          export GITHUB_REPOSITORY=acme/widgets
+          export GITHUB_SHA=deadbeef
+          export GITHUB_BASE_REF=main
+          export GITHUB_STEP_SUMMARY=/tmp/run/step-summary
+          : > "$GITHUB_STEP_SUMMARY"
+          cat > /tmp/run/event.json <<EVT
+          {"pull_request":{"head":{"sha":"deadbeef"},"base":{"sha":"baadcafe"}}}
+          EVT
+          export GITHUB_EVENT_PATH=/tmp/run/event.json
+
+          export PATH=/tmp/stub:$PATH
+          set +e
+          out=$(./pr-comment/entrypoint.sh \
+            'specs/base.yaml' 'specs/revision.yaml' \
+            '' '' '' 'stub-oasdiff-token' '' '' 2>&1)
+          rc=$?
+          set -e
+          echo "--- entrypoint output ---"; echo "$out"
+          echo "--- exit code: $rc ---"
+          echo "--- step summary ---"; cat "$GITHUB_STEP_SUMMARY"
+
+          if [ "$rc" -ne 0 ]; then
+            echo "FAIL: expected exit 0 (warn-don't-fail), got $rc" >&2
+            exit 1
+          fi
+          if ! echo "$out" | grep -q "::warning title=oasdiff plan limit reached::"; then
+            echo "FAIL: missing repo-limit warning annotation" >&2
+            exit 1
+          fi
+          if ! grep -q "oasdiff plan limit reached" "$GITHUB_STEP_SUMMARY"; then
+            echo "FAIL: repo-limit step summary not written" >&2
+            exit 1
+          fi
+          if echo "$out" | grep -q "oasdiff-service returned HTTP"; then
+            echo "FAIL: fell through to the generic non-2xx branch" >&2
+            exit 1
+          fi
+          echo "PASS"

--- a/pr-comment/entrypoint.sh
+++ b/pr-comment/entrypoint.sh
@@ -198,6 +198,28 @@ elif [ "$http_code" = "409" ] && [ "$(echo "$body" | jq -r '.code // empty' 2>/d
         echo "3. Re-run this workflow"
     } >> "$GITHUB_STEP_SUMMARY"
     exit 1
+elif [ "$http_code" = "402" ] && [ "$(echo "$body" | jq -r '.code // empty' 2>/dev/null)" = "repo_limit_reached" ]; then
+    # The service returns 402 with a structured JSON body when this PR's
+    # repository is beyond the tenant's plan limit. This is a billing signal,
+    # not a failure, so surface a clear annotation + step summary with the
+    # upgrade link but do NOT fail the workflow (exit 0): a plan limit should
+    # not break the customer's merge gate. Change the exit below to 1 if you
+    # would rather hard-gate repositories beyond the plan.
+    err_owner=$(echo "$body" | jq -r '.owner')
+    err_repo=$(echo "$body" | jq -r '.repo')
+    max_repos=$(echo "$body" | jq -r '.max_repos')
+    upgrade_url=$(echo "$body" | jq -r '.upgrade_url')
+    echo "::warning title=oasdiff plan limit reached::${err_owner}/${err_repo} is beyond your plan's ${max_repos}-repository limit, so no review comment was posted. Upgrade at ${upgrade_url} to add it."
+    {
+        echo "### ⚠️ oasdiff plan limit reached"
+        echo ""
+        echo "Your oasdiff plan covers **${max_repos} repositories**. **${err_owner}/${err_repo}** is beyond that limit, so no review comment was posted for this pull request."
+        echo ""
+        echo "**To cover this repository:** [upgrade your plan](${upgrade_url})."
+        echo ""
+        echo "_Repositories already counted toward your plan are unaffected._"
+    } >> "$GITHUB_STEP_SUMMARY"
+    exit 0
 else
     echo "ERROR: oasdiff-service returned HTTP $http_code" >&2
     echo "$body" >&2


### PR DESCRIPTION
## What

When the oasdiff service responds with **HTTP 402** and code `repo_limit_reached` (the pull request's repository is beyond the plan's repository limit), the `pr-comment` action previously fell through to the generic non-2xx branch, which dumped the raw JSON body to stderr and failed the step. A maintainer just saw a failed check and had to dig through the raw log to learn it was a plan-limit issue.

This adds a dedicated branch that surfaces it properly:

- A clear **`::warning::` annotation** with the repo, the plan limit, and the upgrade link.
- A **Step Summary** block explaining that no review comment was posted and how to cover the repository.
- Mirrors the existing `github_app_not_installed` (409) handling right above it.

## Behavior: warns, does not fail

The workflow is **not** failed (`exit 0`). A billing limit should not break the customer's merge gate, and the visible warning plus the missing PR comment are signal enough. Flip the single `exit 0` to `exit 1` if you would rather hard-gate repositories beyond the plan.

The "View API changes" notice (free review link) is still emitted beforehand, so an over-limit repo keeps the free fallback path.

## Test

Adds `pr_comment_repo_limit_warns_without_failing`: stubs `oasdiff` and `curl` to return the 402 `repo_limit_reached` response, then asserts the warning annotation, the step summary, `exit 0`, and that it does not regress to the generic error branch. Verified locally.
