### PR TITLE
Remove internal doc path from step-summary comments

### DIFF
--- a/breaking/entrypoint.sh
+++ b/breaking/entrypoint.sh
@@ -160,7 +160,6 @@ if [ -n "$breaking_changes" ] && ! echo "$breaking_changes" | head -n 1 | grep -
     # fenced code block with a built-in copy button, so the one-step path
     # for the familiar-visitor cohort is: scroll to the Checks tab, click
     # copy on the command, paste into a terminal in the local clone, run.
-    # See enterprise/docs/cli-local-review.md (Phase 1, step 5).
     {
         echo "### 📋 [Review & approve these breaking changes](${free_review_url})"
         echo ""

--- a/changelog/entrypoint.sh
+++ b/changelog/entrypoint.sh
@@ -152,8 +152,7 @@ if [ -n "$output" ] && ! echo "$output" | head -n 1 | grep -q "^No "; then
     # The Step Summary surfaces both the link (for visitors who'd rather use
     # the web UI) and the CLI command itself (for visitors who recognize it
     # and want to skip the instruction-page detour). GitHub renders the
-    # fenced code block with a built-in copy button. See
-    # enterprise/docs/cli-local-review.md (Phase 1, step 5).
+    # fenced code block with a built-in copy button.
     {
         echo "### 📋 [Review & approve these API changes](${free_review_url})"
         echo ""


### PR DESCRIPTION
The `breaking` and `changelog` entrypoints each carried a code comment pointing at an internal design doc by file path. These are public files, so the reference is both a dead link for anyone reading the action source and an unnecessary signal that internal material exists at that path.

This drops the two comment lines. No behavior change: the surrounding comment already explains what the step summary renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)