### PR TITLE
Prepend git fetch to the local-review command in the step summary

### DIFF
--- a/breaking/entrypoint.sh
+++ b/breaking/entrypoint.sh
@@ -167,7 +167,7 @@ if [ -n "$breaking_changes" ] && ! echo "$breaking_changes" | head -n 1 | grep -
         echo "Or run locally in your clone of \`${repo}\`:"
         echo ""
         echo '```bash'
-        echo "oasdiff breaking ${base_sha}:${base_path} ${head_sha}:${rev_path} --open"
+        echo "git fetch origin ${base_sha} ${head_sha} && oasdiff breaking ${base_sha}:${base_path} ${head_sha}:${rev_path} --open"
         echo '```'
     } >> "$GITHUB_STEP_SUMMARY"
 else

--- a/changelog/entrypoint.sh
+++ b/changelog/entrypoint.sh
@@ -160,7 +160,7 @@ if [ -n "$output" ] && ! echo "$output" | head -n 1 | grep -q "^No "; then
         echo "Or run locally in your clone of \`${repo}\`:"
         echo ""
         echo '```bash'
-        echo "oasdiff changelog ${base_sha}:${base_path} ${head_sha}:${rev_path} --open"
+        echo "git fetch origin ${base_sha} ${head_sha} && oasdiff changelog ${base_sha}:${base_path} ${head_sha}:${rev_path} --open"
         echo '```'
     } >> "$GITHUB_STEP_SUMMARY"
 else


### PR DESCRIPTION
The free `breaking` and `changelog` actions write a copy-friendly "Or run locally in your clone" command to the step summary, using the `<sha>:<path>` form.

oasdiff resolves that form with `git show`, which only sees objects already present in the local clone. A reviewer who copies the block without having fetched the PR commit, or whose clone is shallow and lacks the base commit, hits an `invalid object` error.

This prepends `git fetch origin <base_sha> <head_sha>` so both commits are present before oasdiff runs. The fetch is a no-op when the objects are already local, so it is harmless for the PR author whose clone is current. It matches the command the `/review` instruction page already emits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)