### PR TITLE
ci: authenticate to Docker Hub in test workflows to avoid pull rate limits

### DIFF
--- a/.github/workflows/test-breaking.yaml
+++ b/.github/workflows/test-breaking.yaml
@@ -2,6 +2,9 @@ name: breaking
 on:
   pull_request:
   push:
+env:
+  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+  DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 jobs:
   oasdiff_breaking:
     runs-on: ubuntu-latest
@@ -9,6 +12,12 @@ jobs:
     env:
       OASDIFF_ACTION_TEST_EXPECTED_OUTPUT: "1 changes: 1 error, 0 warning, 0 info"
     steps:
+      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
+        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
       - name: checkout
         uses: actions/checkout@v6
       - name: Running breaking action
@@ -46,6 +55,12 @@ jobs:
     env:
       OASDIFF_ACTION_TEST_EXPECTED_OUTPUT: "2 changes: 0 error, 2 warning, 0 info"
     steps:
+      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
+        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
       - name: checkout
         uses: actions/checkout@v6
       - name: Running breaking action
@@ -84,6 +99,12 @@ jobs:
       env:
         OASDIFF_ACTION_TEST_EXPECTED_OUTPUT: "9 changes: 6 error, 3 warning, 0 info"
       steps:
+        - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
+          if: ${{ env.DOCKERHUB_TOKEN != '' }}
+          uses: docker/login-action@v3
+          with:
+            username: ${{ env.DOCKERHUB_USERNAME }}
+            password: ${{ env.DOCKERHUB_TOKEN }}
         - name: checkout
           uses: actions/checkout@v6
         - name: Running breaking action with petsotre to validate no error of unable to process file command 'output' successfully and invalid value and matching delimiter not found
@@ -109,6 +130,12 @@ jobs:
     env:
         OASDIFF_ACTION_TEST_EXPECTED_OUTPUT: "1 changes: 1 error, 0 warning, 0 info"
     steps:
+        - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
+          if: ${{ env.DOCKERHUB_TOKEN != '' }}
+          uses: docker/login-action@v3
+          with:
+            username: ${{ env.DOCKERHUB_USERNAME }}
+            password: ${{ env.DOCKERHUB_TOKEN }}
         - name: checkout
           uses: actions/checkout@v6
         - name: Running breaking action with composed option
@@ -133,6 +160,12 @@ jobs:
     runs-on: ubuntu-latest
     name: Test breaking changes with deprecation
     steps:
+      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
+        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
       - name: checkout
         uses: actions/checkout@v6
       - name: Set date for deprecated specs
@@ -155,6 +188,12 @@ jobs:
     env:
       OASDIFF_ACTION_TEST_EXPECTED_OUTPUT: "1 changes: 1 error, 0 warning, 0 info"
     steps:
+      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
+        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
       - name: checkout
         uses: actions/checkout@v6
       - name: Running breaking action with flatten-allof option
@@ -179,6 +218,12 @@ jobs:
     runs-on: ubuntu-latest
     name: Test breaking action with err-ignore option
     steps:
+      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
+        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
       - name: checkout
         uses: actions/checkout@v6
       - name: Running breaking action with err-ignore option
@@ -211,6 +256,12 @@ jobs:
     runs-on: ubuntu-latest
     name: Test breaking action picks up fail-on from .oasdiff.yaml
     steps:
+      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
+        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
       - name: checkout
         uses: actions/checkout@v6
       - name: Drop .oasdiff.yaml at repo root
@@ -248,6 +299,12 @@ jobs:
     runs-on: ubuntu-latest
     name: Test breaking action picks up err-ignore from .oasdiff.yaml
     steps:
+      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
+        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
       - name: checkout
         uses: actions/checkout@v6
       - name: Drop .oasdiff.yaml at repo root
@@ -283,6 +340,12 @@ jobs:
     # output. openapi-test1 -> openapi-test3 has breaking changes, so the notice
     # (and review_url) fire.
     steps:
+      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
+        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v6
       - uses: ./breaking
         id: brk
@@ -316,6 +379,12 @@ jobs:
     # have its ref prefix stripped so base_file is just the path. Also exercises
     # real git-ref resolution, the action's recommended base form.
     steps:
+      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
+        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v6
       - uses: ./breaking
         id: brk

--- a/.github/workflows/test-changelog.yaml
+++ b/.github/workflows/test-changelog.yaml
@@ -2,6 +2,9 @@ name: changelog
 on:
   pull_request:
   push:
+env:
+  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+  DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 jobs:
   oasdiff_changelog:
     runs-on: ubuntu-latest
@@ -9,6 +12,12 @@ jobs:
     env:
       OASDIFF_ACTION_TEST_EXPECTED_OUTPUT: "21 changes: 2 error, 4 warning, 15 info"
     steps:
+      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
+        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
       - name: checkout
         uses: actions/checkout@v6
       - name: Running changelog action
@@ -40,6 +49,12 @@ jobs:
     runs-on: ubuntu-latest
     name: Test changelog action with composed option
     steps:
+        - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
+          if: ${{ env.DOCKERHUB_TOKEN != '' }}
+          uses: docker/login-action@v3
+          with:
+            username: ${{ env.DOCKERHUB_USERNAME }}
+            password: ${{ env.DOCKERHUB_TOKEN }}
         - name: checkout
           uses: actions/checkout@v6
         - name: Running changelog action with composed option
@@ -64,6 +79,12 @@ jobs:
     runs-on: ubuntu-latest
     name: Test changelog action picks up level from .oasdiff.yaml
     steps:
+      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
+        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
       - name: checkout
         uses: actions/checkout@v6
       - name: Drop .oasdiff.yaml at repo root
@@ -95,6 +116,12 @@ jobs:
     # its Alpine container (the production platform) and asserts on the
     # review_url output.
     steps:
+      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
+        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v6
       - uses: ./changelog
         id: clog
@@ -128,6 +155,12 @@ jobs:
     # have its ref prefix stripped so base_file is just the path. Also exercises
     # real git-ref resolution, the action's recommended base form.
     steps:
+      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
+        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v6
       - uses: ./changelog
         id: clog

--- a/.github/workflows/test-diff.yaml
+++ b/.github/workflows/test-diff.yaml
@@ -2,11 +2,20 @@ name: diff
 on:
   pull_request:
   push:
+env:
+  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+  DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 jobs:
   oasdiff_diff:
     runs-on: ubuntu-latest
     name: Test diff action
     steps:
+      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
+        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
       - name: checkout
         uses: actions/checkout@v6
       - name: Running diff action
@@ -27,6 +36,12 @@ jobs:
     runs-on: ubuntu-latest
     name: Test diff action with exclude-elements option
     steps:
+        - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
+          if: ${{ env.DOCKERHUB_TOKEN != '' }}
+          uses: docker/login-action@v3
+          with:
+            username: ${{ env.DOCKERHUB_USERNAME }}
+            password: ${{ env.DOCKERHUB_TOKEN }}
         - name: checkout
           uses: actions/checkout@v6
         - name: Running diff action with exclude-elements option
@@ -52,6 +67,12 @@ jobs:
     runs-on: ubuntu-latest
     name: Test diff action with composed option
     steps:
+        - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
+          if: ${{ env.DOCKERHUB_TOKEN != '' }}
+          uses: docker/login-action@v3
+          with:
+            username: ${{ env.DOCKERHUB_USERNAME }}
+            password: ${{ env.DOCKERHUB_TOKEN }}
         - name: checkout
           uses: actions/checkout@v6
         - name: Running diff action with composed option
@@ -77,6 +98,12 @@ jobs:
     runs-on: ubuntu-latest
     name: Test diff action picks up exclude-elements from .oasdiff.yaml
     steps:
+      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
+        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
       - name: checkout
         uses: actions/checkout@v6
       - name: Drop .oasdiff.yaml at repo root

--- a/.github/workflows/test-error-annotation.yaml
+++ b/.github/workflows/test-error-annotation.yaml
@@ -2,11 +2,20 @@ name: error-annotation
 on:
   pull_request:
   push:
+env:
+  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+  DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 jobs:
   entrypoint_error_annotation:
     runs-on: ubuntu-latest
     name: Entrypoints surface genuine errors as annotations, not success/fail-on
     steps:
+      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
+        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
       - name: checkout
         uses: actions/checkout@v6
       - name: Exercise every entrypoint with a stubbed oasdiff

--- a/.github/workflows/test-pr-comment.yaml
+++ b/.github/workflows/test-pr-comment.yaml
@@ -2,11 +2,20 @@ name: pr-comment
 on:
   pull_request:
   push:
+env:
+  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+  DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 jobs:
   pr_comment_tolerates_oasdiff_fail_on:
     runs-on: ubuntu-latest
     name: Test pr-comment proceeds when oasdiff exits non-zero with output
     steps:
+      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
+        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v6
       - name: Stub oasdiff to simulate fail-on triggered
         run: |
@@ -65,6 +74,12 @@ jobs:
     runs-on: ubuntu-latest
     name: Test pr-comment aborts when oasdiff exits non-zero with no output
     steps:
+      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
+        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v6
       - name: Stub oasdiff to simulate a real failure
         run: |
@@ -128,6 +143,12 @@ jobs:
     # without aborting, which proves the jq invocation processed the
     # payload successfully.
     steps:
+      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
+        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v6
       - name: Stub oasdiff to emit a multi-MB changelog
         run: |
@@ -205,6 +226,12 @@ jobs:
     # invocation already succeeded — the same ARG_MAX trap one layer
     # down. The fix pipes the payload through stdin via `--data-binary @-`.
     steps:
+      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
+        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v6
       - name: Stub oasdiff + curl, run entrypoint with a fake token
         run: |
@@ -296,6 +323,12 @@ jobs:
     # generic access-denied screen masked the real cause (malformed URL).
     # The fix passes URL-shaped inputs through unchanged.
     steps:
+      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
+        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v6
       - name: Stub oasdiff to a no-changes spec
         run: |
@@ -354,6 +387,12 @@ jobs:
     # path. The previous sed-based implementation handled this correctly;
     # this test guards the case-branch refactor against breaking it.
     steps:
+      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
+        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v6
       - name: Stub oasdiff to a no-changes spec
         run: |
@@ -403,6 +442,12 @@ jobs:
     # billing limit shouldn't break the customer's merge gate. Guards against
     # regressing to the generic non-2xx branch, which dumps raw JSON and exits 1.
     steps:
+      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
+        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v6
       - name: Stub oasdiff + curl (402), run entrypoint with a fake token
         run: |

--- a/.github/workflows/test-validate.yaml
+++ b/.github/workflows/test-validate.yaml
@@ -2,11 +2,20 @@ name: validate
 on:
   pull_request:
   push:
+env:
+  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+  DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 jobs:
   oasdiff_validate_valid:
     runs-on: ubuntu-latest
     name: Test validate on a valid spec
     steps:
+      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
+        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
       - name: checkout
         uses: actions/checkout@v6
       - name: Running validate action on a valid spec
@@ -25,6 +34,12 @@ jobs:
     runs-on: ubuntu-latest
     name: Test validate fails on an invalid spec
     steps:
+      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
+        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
       - name: checkout
         uses: actions/checkout@v6
       - name: Running validate action on an invalid spec
@@ -48,6 +63,12 @@ jobs:
     runs-on: ubuntu-latest
     name: Test validate severity threshold (--fail-on)
     steps:
+      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
+        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
       - name: checkout
         uses: actions/checkout@v6
       - name: Validate a warning-only spec with the default threshold

--- a/.github/workflows/test-verify.yaml
+++ b/.github/workflows/test-verify.yaml
@@ -3,6 +3,9 @@ on:
   push:
   pull_request:
 
+env:
+  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+  DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 jobs:
   verify_all_green:
     runs-on: ubuntu-latest
@@ -10,6 +13,12 @@ jobs:
     # Stub oasdiff (specs resolve) + curl (service returns all checks true) and
     # assert the entrypoint renders a full-green checklist and exits 0.
     steps:
+      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
+        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v6
       - name: Stub oasdiff + curl, run verify entrypoint
         run: |
@@ -54,6 +63,12 @@ jobs:
     # Service reports app_installed=false: the entrypoint must mark that check
     # red, emit an annotation, and exit 1 (setup not complete).
     steps:
+      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
+        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v6
       - name: Stub oasdiff + curl (app not installed)
         run: |
@@ -98,6 +113,12 @@ jobs:
     # false). Verify must report that distinctly from "spec not found" — with
     # the allow-external-refs hint, not a path hint — and exit 1.
     steps:
+      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
+        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v6
       - name: Stub oasdiff (exit 123) + curl
         run: |


### PR DESCRIPTION
## Problem

The action images build `FROM tufin/oasdiff` (Docker Hub). The test workflows build them across ~34 jobs, all **anonymous** pulls, which exhausts Docker Hub's anonymous pull-rate limit (the GitHub runner IP pool is shared) and intermittently times out against `registry-1.docker.io`. Symptoms in failing runs:

```
load metadata for docker.io/tufin/oasdiff:v1.18.2
ERROR: failed to resolve source metadata ... registry-1.docker.io ... i/o timeout / DeadlineExceeded
```

## Fix

Add a `docker/login-action@v3` step to every job, before the action runs, so the base image is pulled with an authenticated session (much higher limit, more reliable). It is **gated** on the token being present:

```yaml
- if: ${{ env.DOCKERHUB_TOKEN != '' }}
  uses: docker/login-action@v3
  with:
    username: ${{ env.DOCKERHUB_USERNAME }}
    password: ${{ env.DOCKERHUB_TOKEN }}
```

so fork PRs (no secrets) fall back to anonymous exactly as today, and the change is a no-op until the secrets are configured.

## Required to take effect

Add these as repo (or org) Actions secrets:
- `DOCKERHUB_USERNAME` - the Docker Hub account used for the `tufin/oasdiff` image
- `DOCKERHUB_TOKEN` - a Docker Hub **access token** (read-only is enough for pulls)

Until they are set, the login step is skipped and CI behaves as before (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)