### PR TITLE
ci: fix Docker Hub login never running (secrets unavailable in top-level env)

### DIFF
--- a/.github/workflows/test-breaking.yaml
+++ b/.github/workflows/test-breaking.yaml
@@ -2,9 +2,6 @@ name: breaking
 on:
   pull_request:
   push:
-env:
-  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-  DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 jobs:
   oasdiff_breaking:
     runs-on: ubuntu-latest
@@ -13,11 +10,11 @@ jobs:
       OASDIFF_ACTION_TEST_EXPECTED_OUTPUT: "1 changes: 1 error, 0 warning, 0 info"
     steps:
       - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: docker/login-action@v3
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: checkout
         uses: actions/checkout@v6
       - name: Running breaking action
@@ -56,11 +53,11 @@ jobs:
       OASDIFF_ACTION_TEST_EXPECTED_OUTPUT: "2 changes: 0 error, 2 warning, 0 info"
     steps:
       - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: docker/login-action@v3
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: checkout
         uses: actions/checkout@v6
       - name: Running breaking action
@@ -100,11 +97,11 @@ jobs:
         OASDIFF_ACTION_TEST_EXPECTED_OUTPUT: "9 changes: 6 error, 3 warning, 0 info"
       steps:
         - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-          if: ${{ env.DOCKERHUB_TOKEN != '' }}
+          if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
           uses: docker/login-action@v3
           with:
-            username: ${{ env.DOCKERHUB_USERNAME }}
-            password: ${{ env.DOCKERHUB_TOKEN }}
+            username: ${{ secrets.DOCKERHUB_USERNAME }}
+            password: ${{ secrets.DOCKERHUB_TOKEN }}
         - name: checkout
           uses: actions/checkout@v6
         - name: Running breaking action with petsotre to validate no error of unable to process file command 'output' successfully and invalid value and matching delimiter not found
@@ -131,11 +128,11 @@ jobs:
         OASDIFF_ACTION_TEST_EXPECTED_OUTPUT: "1 changes: 1 error, 0 warning, 0 info"
     steps:
         - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-          if: ${{ env.DOCKERHUB_TOKEN != '' }}
+          if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
           uses: docker/login-action@v3
           with:
-            username: ${{ env.DOCKERHUB_USERNAME }}
-            password: ${{ env.DOCKERHUB_TOKEN }}
+            username: ${{ secrets.DOCKERHUB_USERNAME }}
+            password: ${{ secrets.DOCKERHUB_TOKEN }}
         - name: checkout
           uses: actions/checkout@v6
         - name: Running breaking action with composed option
@@ -161,11 +158,11 @@ jobs:
     name: Test breaking changes with deprecation
     steps:
       - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: docker/login-action@v3
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: checkout
         uses: actions/checkout@v6
       - name: Set date for deprecated specs
@@ -189,11 +186,11 @@ jobs:
       OASDIFF_ACTION_TEST_EXPECTED_OUTPUT: "1 changes: 1 error, 0 warning, 0 info"
     steps:
       - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: docker/login-action@v3
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: checkout
         uses: actions/checkout@v6
       - name: Running breaking action with flatten-allof option
@@ -219,11 +216,11 @@ jobs:
     name: Test breaking action with err-ignore option
     steps:
       - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: docker/login-action@v3
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: checkout
         uses: actions/checkout@v6
       - name: Running breaking action with err-ignore option
@@ -257,11 +254,11 @@ jobs:
     name: Test breaking action picks up fail-on from .oasdiff.yaml
     steps:
       - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: docker/login-action@v3
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: checkout
         uses: actions/checkout@v6
       - name: Drop .oasdiff.yaml at repo root
@@ -300,11 +297,11 @@ jobs:
     name: Test breaking action picks up err-ignore from .oasdiff.yaml
     steps:
       - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: docker/login-action@v3
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: checkout
         uses: actions/checkout@v6
       - name: Drop .oasdiff.yaml at repo root
@@ -341,11 +338,11 @@ jobs:
     # (and review_url) fire.
     steps:
       - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: docker/login-action@v3
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v6
       - uses: ./breaking
         id: brk
@@ -380,11 +377,11 @@ jobs:
     # real git-ref resolution, the action's recommended base form.
     steps:
       - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: docker/login-action@v3
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v6
       - uses: ./breaking
         id: brk

--- a/.github/workflows/test-changelog.yaml
+++ b/.github/workflows/test-changelog.yaml
@@ -2,9 +2,6 @@ name: changelog
 on:
   pull_request:
   push:
-env:
-  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-  DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 jobs:
   oasdiff_changelog:
     runs-on: ubuntu-latest
@@ -13,11 +10,11 @@ jobs:
       OASDIFF_ACTION_TEST_EXPECTED_OUTPUT: "21 changes: 2 error, 4 warning, 15 info"
     steps:
       - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: docker/login-action@v3
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: checkout
         uses: actions/checkout@v6
       - name: Running changelog action
@@ -50,11 +47,11 @@ jobs:
     name: Test changelog action with composed option
     steps:
         - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-          if: ${{ env.DOCKERHUB_TOKEN != '' }}
+          if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
           uses: docker/login-action@v3
           with:
-            username: ${{ env.DOCKERHUB_USERNAME }}
-            password: ${{ env.DOCKERHUB_TOKEN }}
+            username: ${{ secrets.DOCKERHUB_USERNAME }}
+            password: ${{ secrets.DOCKERHUB_TOKEN }}
         - name: checkout
           uses: actions/checkout@v6
         - name: Running changelog action with composed option
@@ -80,11 +77,11 @@ jobs:
     name: Test changelog action picks up level from .oasdiff.yaml
     steps:
       - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: docker/login-action@v3
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: checkout
         uses: actions/checkout@v6
       - name: Drop .oasdiff.yaml at repo root
@@ -117,11 +114,11 @@ jobs:
     # review_url output.
     steps:
       - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: docker/login-action@v3
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v6
       - uses: ./changelog
         id: clog
@@ -156,11 +153,11 @@ jobs:
     # real git-ref resolution, the action's recommended base form.
     steps:
       - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: docker/login-action@v3
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v6
       - uses: ./changelog
         id: clog

--- a/.github/workflows/test-diff.yaml
+++ b/.github/workflows/test-diff.yaml
@@ -2,20 +2,17 @@ name: diff
 on:
   pull_request:
   push:
-env:
-  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-  DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 jobs:
   oasdiff_diff:
     runs-on: ubuntu-latest
     name: Test diff action
     steps:
       - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: docker/login-action@v3
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: checkout
         uses: actions/checkout@v6
       - name: Running diff action
@@ -37,11 +34,11 @@ jobs:
     name: Test diff action with exclude-elements option
     steps:
         - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-          if: ${{ env.DOCKERHUB_TOKEN != '' }}
+          if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
           uses: docker/login-action@v3
           with:
-            username: ${{ env.DOCKERHUB_USERNAME }}
-            password: ${{ env.DOCKERHUB_TOKEN }}
+            username: ${{ secrets.DOCKERHUB_USERNAME }}
+            password: ${{ secrets.DOCKERHUB_TOKEN }}
         - name: checkout
           uses: actions/checkout@v6
         - name: Running diff action with exclude-elements option
@@ -68,11 +65,11 @@ jobs:
     name: Test diff action with composed option
     steps:
         - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-          if: ${{ env.DOCKERHUB_TOKEN != '' }}
+          if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
           uses: docker/login-action@v3
           with:
-            username: ${{ env.DOCKERHUB_USERNAME }}
-            password: ${{ env.DOCKERHUB_TOKEN }}
+            username: ${{ secrets.DOCKERHUB_USERNAME }}
+            password: ${{ secrets.DOCKERHUB_TOKEN }}
         - name: checkout
           uses: actions/checkout@v6
         - name: Running diff action with composed option
@@ -99,11 +96,11 @@ jobs:
     name: Test diff action picks up exclude-elements from .oasdiff.yaml
     steps:
       - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: docker/login-action@v3
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: checkout
         uses: actions/checkout@v6
       - name: Drop .oasdiff.yaml at repo root

--- a/.github/workflows/test-error-annotation.yaml
+++ b/.github/workflows/test-error-annotation.yaml
@@ -2,20 +2,17 @@ name: error-annotation
 on:
   pull_request:
   push:
-env:
-  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-  DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 jobs:
   entrypoint_error_annotation:
     runs-on: ubuntu-latest
     name: Entrypoints surface genuine errors as annotations, not success/fail-on
     steps:
       - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: docker/login-action@v3
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: checkout
         uses: actions/checkout@v6
       - name: Exercise every entrypoint with a stubbed oasdiff

--- a/.github/workflows/test-pr-comment.yaml
+++ b/.github/workflows/test-pr-comment.yaml
@@ -2,20 +2,17 @@ name: pr-comment
 on:
   pull_request:
   push:
-env:
-  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-  DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 jobs:
   pr_comment_tolerates_oasdiff_fail_on:
     runs-on: ubuntu-latest
     name: Test pr-comment proceeds when oasdiff exits non-zero with output
     steps:
       - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: docker/login-action@v3
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v6
       - name: Stub oasdiff to simulate fail-on triggered
         run: |
@@ -75,11 +72,11 @@ jobs:
     name: Test pr-comment aborts when oasdiff exits non-zero with no output
     steps:
       - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: docker/login-action@v3
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v6
       - name: Stub oasdiff to simulate a real failure
         run: |
@@ -144,11 +141,11 @@ jobs:
     # payload successfully.
     steps:
       - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: docker/login-action@v3
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v6
       - name: Stub oasdiff to emit a multi-MB changelog
         run: |
@@ -227,11 +224,11 @@ jobs:
     # down. The fix pipes the payload through stdin via `--data-binary @-`.
     steps:
       - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: docker/login-action@v3
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v6
       - name: Stub oasdiff + curl, run entrypoint with a fake token
         run: |
@@ -324,11 +321,11 @@ jobs:
     # The fix passes URL-shaped inputs through unchanged.
     steps:
       - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: docker/login-action@v3
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v6
       - name: Stub oasdiff to a no-changes spec
         run: |
@@ -388,11 +385,11 @@ jobs:
     # this test guards the case-branch refactor against breaking it.
     steps:
       - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: docker/login-action@v3
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v6
       - name: Stub oasdiff to a no-changes spec
         run: |
@@ -443,11 +440,11 @@ jobs:
     # regressing to the generic non-2xx branch, which dumps raw JSON and exits 1.
     steps:
       - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: docker/login-action@v3
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v6
       - name: Stub oasdiff + curl (402), run entrypoint with a fake token
         run: |

--- a/.github/workflows/test-validate.yaml
+++ b/.github/workflows/test-validate.yaml
@@ -2,20 +2,17 @@ name: validate
 on:
   pull_request:
   push:
-env:
-  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-  DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 jobs:
   oasdiff_validate_valid:
     runs-on: ubuntu-latest
     name: Test validate on a valid spec
     steps:
       - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: docker/login-action@v3
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: checkout
         uses: actions/checkout@v6
       - name: Running validate action on a valid spec
@@ -35,11 +32,11 @@ jobs:
     name: Test validate fails on an invalid spec
     steps:
       - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: docker/login-action@v3
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: checkout
         uses: actions/checkout@v6
       - name: Running validate action on an invalid spec
@@ -64,11 +61,11 @@ jobs:
     name: Test validate severity threshold (--fail-on)
     steps:
       - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: docker/login-action@v3
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: checkout
         uses: actions/checkout@v6
       - name: Validate a warning-only spec with the default threshold

--- a/.github/workflows/test-verify.yaml
+++ b/.github/workflows/test-verify.yaml
@@ -3,9 +3,6 @@ on:
   push:
   pull_request:
 
-env:
-  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-  DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 jobs:
   verify_all_green:
     runs-on: ubuntu-latest
@@ -14,11 +11,11 @@ jobs:
     # assert the entrypoint renders a full-green checklist and exits 0.
     steps:
       - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: docker/login-action@v3
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v6
       - name: Stub oasdiff + curl, run verify entrypoint
         run: |
@@ -64,11 +61,11 @@ jobs:
     # red, emit an annotation, and exit 1 (setup not complete).
     steps:
       - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: docker/login-action@v3
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v6
       - name: Stub oasdiff + curl (app not installed)
         run: |
@@ -114,11 +111,11 @@ jobs:
     # the allow-external-refs hint, not a path hint — and exit 1.
     steps:
       - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: docker/login-action@v3
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v6
       - name: Stub oasdiff (exit 123) + curl
         run: |


### PR DESCRIPTION
Follow-up to #139. The login step it added was **skipped on every job** even after the `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` secrets were set (verified: 7/7 skipped on main), so the rate-limit error persisted.

**Cause:** the gating used a top-level `env:` populated from `${{ secrets.* }}`, but the `secrets` context is **not available in workflow-level `env`** — those vars rendered empty, so `if: env.DOCKERHUB_TOKEN != ''` was always false.

**Fix:** reference the secrets directly in the step `with:` (where `secrets` *is* available) and gate on the `github` context instead:

```yaml
- if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
  uses: docker/login-action@v3
  with:
    username: ${{ secrets.DOCKERHUB_USERNAME }}
    password: ${{ secrets.DOCKERHUB_TOKEN }}
```

This runs the login on `push` and same-repo PRs (secrets present) and skips it only on fork PRs (secrets absent), with no top-level env. Since this PR's branch is in-repo, its own CI exercises the login, so a green run confirms authenticated pulls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)