### PR TITLE
Revert "ci: authenticate to Docker Hub in test workflows" (#139)

### DIFF
--- a/.github/workflows/test-breaking.yaml
+++ b/.github/workflows/test-breaking.yaml
@@ -2,9 +2,6 @@ name: breaking
 on:
   pull_request:
   push:
-env:
-  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-  DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 jobs:
   oasdiff_breaking:
     runs-on: ubuntu-latest
@@ -12,12 +9,6 @@ jobs:
     env:
       OASDIFF_ACTION_TEST_EXPECTED_OUTPUT: "1 changes: 1 error, 0 warning, 0 info"
     steps:
-      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
       - name: checkout
         uses: actions/checkout@v6
       - name: Running breaking action
@@ -55,12 +46,6 @@ jobs:
     env:
       OASDIFF_ACTION_TEST_EXPECTED_OUTPUT: "2 changes: 0 error, 2 warning, 0 info"
     steps:
-      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
       - name: checkout
         uses: actions/checkout@v6
       - name: Running breaking action
@@ -99,12 +84,6 @@ jobs:
       env:
         OASDIFF_ACTION_TEST_EXPECTED_OUTPUT: "9 changes: 6 error, 3 warning, 0 info"
       steps:
-        - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-          if: ${{ env.DOCKERHUB_TOKEN != '' }}
-          uses: docker/login-action@v3
-          with:
-            username: ${{ env.DOCKERHUB_USERNAME }}
-            password: ${{ env.DOCKERHUB_TOKEN }}
         - name: checkout
           uses: actions/checkout@v6
         - name: Running breaking action with petsotre to validate no error of unable to process file command 'output' successfully and invalid value and matching delimiter not found
@@ -130,12 +109,6 @@ jobs:
     env:
         OASDIFF_ACTION_TEST_EXPECTED_OUTPUT: "1 changes: 1 error, 0 warning, 0 info"
     steps:
-        - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-          if: ${{ env.DOCKERHUB_TOKEN != '' }}
-          uses: docker/login-action@v3
-          with:
-            username: ${{ env.DOCKERHUB_USERNAME }}
-            password: ${{ env.DOCKERHUB_TOKEN }}
         - name: checkout
           uses: actions/checkout@v6
         - name: Running breaking action with composed option
@@ -160,12 +133,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Test breaking changes with deprecation
     steps:
-      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
       - name: checkout
         uses: actions/checkout@v6
       - name: Set date for deprecated specs
@@ -188,12 +155,6 @@ jobs:
     env:
       OASDIFF_ACTION_TEST_EXPECTED_OUTPUT: "1 changes: 1 error, 0 warning, 0 info"
     steps:
-      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
       - name: checkout
         uses: actions/checkout@v6
       - name: Running breaking action with flatten-allof option
@@ -218,12 +179,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Test breaking action with err-ignore option
     steps:
-      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
       - name: checkout
         uses: actions/checkout@v6
       - name: Running breaking action with err-ignore option
@@ -256,12 +211,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Test breaking action picks up fail-on from .oasdiff.yaml
     steps:
-      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
       - name: checkout
         uses: actions/checkout@v6
       - name: Drop .oasdiff.yaml at repo root
@@ -299,12 +248,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Test breaking action picks up err-ignore from .oasdiff.yaml
     steps:
-      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
       - name: checkout
         uses: actions/checkout@v6
       - name: Drop .oasdiff.yaml at repo root
@@ -340,12 +283,6 @@ jobs:
     # output. openapi-test1 -> openapi-test3 has breaking changes, so the notice
     # (and review_url) fire.
     steps:
-      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v6
       - uses: ./breaking
         id: brk
@@ -379,12 +316,6 @@ jobs:
     # have its ref prefix stripped so base_file is just the path. Also exercises
     # real git-ref resolution, the action's recommended base form.
     steps:
-      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v6
       - uses: ./breaking
         id: brk

--- a/.github/workflows/test-changelog.yaml
+++ b/.github/workflows/test-changelog.yaml
@@ -2,9 +2,6 @@ name: changelog
 on:
   pull_request:
   push:
-env:
-  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-  DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 jobs:
   oasdiff_changelog:
     runs-on: ubuntu-latest
@@ -12,12 +9,6 @@ jobs:
     env:
       OASDIFF_ACTION_TEST_EXPECTED_OUTPUT: "21 changes: 2 error, 4 warning, 15 info"
     steps:
-      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
       - name: checkout
         uses: actions/checkout@v6
       - name: Running changelog action
@@ -49,12 +40,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Test changelog action with composed option
     steps:
-        - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-          if: ${{ env.DOCKERHUB_TOKEN != '' }}
-          uses: docker/login-action@v3
-          with:
-            username: ${{ env.DOCKERHUB_USERNAME }}
-            password: ${{ env.DOCKERHUB_TOKEN }}
         - name: checkout
           uses: actions/checkout@v6
         - name: Running changelog action with composed option
@@ -79,12 +64,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Test changelog action picks up level from .oasdiff.yaml
     steps:
-      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
       - name: checkout
         uses: actions/checkout@v6
       - name: Drop .oasdiff.yaml at repo root
@@ -116,12 +95,6 @@ jobs:
     # its Alpine container (the production platform) and asserts on the
     # review_url output.
     steps:
-      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v6
       - uses: ./changelog
         id: clog
@@ -155,12 +128,6 @@ jobs:
     # have its ref prefix stripped so base_file is just the path. Also exercises
     # real git-ref resolution, the action's recommended base form.
     steps:
-      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v6
       - uses: ./changelog
         id: clog

--- a/.github/workflows/test-diff.yaml
+++ b/.github/workflows/test-diff.yaml
@@ -2,20 +2,11 @@ name: diff
 on:
   pull_request:
   push:
-env:
-  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-  DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 jobs:
   oasdiff_diff:
     runs-on: ubuntu-latest
     name: Test diff action
     steps:
-      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
       - name: checkout
         uses: actions/checkout@v6
       - name: Running diff action
@@ -36,12 +27,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Test diff action with exclude-elements option
     steps:
-        - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-          if: ${{ env.DOCKERHUB_TOKEN != '' }}
-          uses: docker/login-action@v3
-          with:
-            username: ${{ env.DOCKERHUB_USERNAME }}
-            password: ${{ env.DOCKERHUB_TOKEN }}
         - name: checkout
           uses: actions/checkout@v6
         - name: Running diff action with exclude-elements option
@@ -67,12 +52,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Test diff action with composed option
     steps:
-        - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-          if: ${{ env.DOCKERHUB_TOKEN != '' }}
-          uses: docker/login-action@v3
-          with:
-            username: ${{ env.DOCKERHUB_USERNAME }}
-            password: ${{ env.DOCKERHUB_TOKEN }}
         - name: checkout
           uses: actions/checkout@v6
         - name: Running diff action with composed option
@@ -98,12 +77,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Test diff action picks up exclude-elements from .oasdiff.yaml
     steps:
-      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
       - name: checkout
         uses: actions/checkout@v6
       - name: Drop .oasdiff.yaml at repo root

--- a/.github/workflows/test-error-annotation.yaml
+++ b/.github/workflows/test-error-annotation.yaml
@@ -2,20 +2,11 @@ name: error-annotation
 on:
   pull_request:
   push:
-env:
-  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-  DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 jobs:
   entrypoint_error_annotation:
     runs-on: ubuntu-latest
     name: Entrypoints surface genuine errors as annotations, not success/fail-on
     steps:
-      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
       - name: checkout
         uses: actions/checkout@v6
       - name: Exercise every entrypoint with a stubbed oasdiff

--- a/.github/workflows/test-pr-comment.yaml
+++ b/.github/workflows/test-pr-comment.yaml
@@ -2,20 +2,11 @@ name: pr-comment
 on:
   pull_request:
   push:
-env:
-  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-  DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 jobs:
   pr_comment_tolerates_oasdiff_fail_on:
     runs-on: ubuntu-latest
     name: Test pr-comment proceeds when oasdiff exits non-zero with output
     steps:
-      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v6
       - name: Stub oasdiff to simulate fail-on triggered
         run: |
@@ -74,12 +65,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Test pr-comment aborts when oasdiff exits non-zero with no output
     steps:
-      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v6
       - name: Stub oasdiff to simulate a real failure
         run: |
@@ -143,12 +128,6 @@ jobs:
     # without aborting, which proves the jq invocation processed the
     # payload successfully.
     steps:
-      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v6
       - name: Stub oasdiff to emit a multi-MB changelog
         run: |
@@ -226,12 +205,6 @@ jobs:
     # invocation already succeeded — the same ARG_MAX trap one layer
     # down. The fix pipes the payload through stdin via `--data-binary @-`.
     steps:
-      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v6
       - name: Stub oasdiff + curl, run entrypoint with a fake token
         run: |
@@ -323,12 +296,6 @@ jobs:
     # generic access-denied screen masked the real cause (malformed URL).
     # The fix passes URL-shaped inputs through unchanged.
     steps:
-      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v6
       - name: Stub oasdiff to a no-changes spec
         run: |
@@ -387,12 +354,6 @@ jobs:
     # path. The previous sed-based implementation handled this correctly;
     # this test guards the case-branch refactor against breaking it.
     steps:
-      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v6
       - name: Stub oasdiff to a no-changes spec
         run: |
@@ -442,12 +403,6 @@ jobs:
     # billing limit shouldn't break the customer's merge gate. Guards against
     # regressing to the generic non-2xx branch, which dumps raw JSON and exits 1.
     steps:
-      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v6
       - name: Stub oasdiff + curl (402), run entrypoint with a fake token
         run: |

--- a/.github/workflows/test-validate.yaml
+++ b/.github/workflows/test-validate.yaml
@@ -2,20 +2,11 @@ name: validate
 on:
   pull_request:
   push:
-env:
-  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-  DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 jobs:
   oasdiff_validate_valid:
     runs-on: ubuntu-latest
     name: Test validate on a valid spec
     steps:
-      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
       - name: checkout
         uses: actions/checkout@v6
       - name: Running validate action on a valid spec
@@ -34,12 +25,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Test validate fails on an invalid spec
     steps:
-      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
       - name: checkout
         uses: actions/checkout@v6
       - name: Running validate action on an invalid spec
@@ -63,12 +48,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Test validate severity threshold (--fail-on)
     steps:
-      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
       - name: checkout
         uses: actions/checkout@v6
       - name: Validate a warning-only spec with the default threshold

--- a/.github/workflows/test-verify.yaml
+++ b/.github/workflows/test-verify.yaml
@@ -3,9 +3,6 @@ on:
   push:
   pull_request:
 
-env:
-  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-  DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 jobs:
   verify_all_green:
     runs-on: ubuntu-latest
@@ -13,12 +10,6 @@ jobs:
     # Stub oasdiff (specs resolve) + curl (service returns all checks true) and
     # assert the entrypoint renders a full-green checklist and exits 0.
     steps:
-      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v6
       - name: Stub oasdiff + curl, run verify entrypoint
         run: |
@@ -63,12 +54,6 @@ jobs:
     # Service reports app_installed=false: the entrypoint must mark that check
     # red, emit an annotation, and exit 1 (setup not complete).
     steps:
-      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v6
       - name: Stub oasdiff + curl (app not installed)
         run: |
@@ -113,12 +98,6 @@ jobs:
     # false). Verify must report that distinctly from "spec not found" — with
     # the allow-external-refs hint, not a path hint — and exit 1.
     steps:
-      - name: Log in to Docker Hub (raises the anonymous pull-rate limit on the action base image)
-        if: ${{ env.DOCKERHUB_TOKEN != '' }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v6
       - name: Stub oasdiff (exit 123) + curl
         run: |


### PR DESCRIPTION
Reverts #139. That change targeted the wrong problem: the "rate limited by upstream service" message is on the org profile page's shields.io Docker-pulls badge, not in CI. Restoring the test workflows to their original state.