### PR TITLE
Stamp the action version on service calls and the /review URL

### DIFF
--- a/breaking/entrypoint.sh
+++ b/breaking/entrypoint.sh
@@ -152,7 +152,7 @@ if [ -n "$breaking_changes" ] && ! echo "$breaking_changes" | head -n 1 | grep -
     # commit where the file lives at a different path.
     base_sha=$(jq -r '.pull_request.base.sha // empty' "$GITHUB_EVENT_PATH" 2>/dev/null || echo "")
     if [ -z "$base_sha" ]; then base_sha=$(git rev-parse "origin/$GITHUB_BASE_REF" 2>/dev/null || echo "$GITHUB_BASE_REF"); fi
-    free_review_url="https://www.oasdiff.com/review?owner=${owner}&repo=${repo}&base_sha=$(urlencode "$base_sha")&rev_sha=${head_sha}&base_file=$(urlencode "$base_path")&rev_file=$(urlencode "$rev_path")"
+    free_review_url="https://www.oasdiff.com/review?owner=${owner}&repo=${repo}&base_sha=$(urlencode "$base_sha")&rev_sha=${head_sha}&base_file=$(urlencode "$base_path")&rev_file=$(urlencode "$rev_path")&action_version=$(urlencode "${GITHUB_ACTION_REF:-unknown}")"
     echo "::notice::📋 Review & approve these breaking changes → ${free_review_url}"
     # The Step Summary surfaces both the link (for visitors who'd rather use
     # the web UI) and the CLI command itself (for visitors who recognize it

--- a/changelog/entrypoint.sh
+++ b/changelog/entrypoint.sh
@@ -147,7 +147,7 @@ if [ -n "$output" ] && ! echo "$output" | head -n 1 | grep -q "^No "; then
     # commit where the file lives at a different path.
     base_sha=$(jq -r '.pull_request.base.sha // empty' "$GITHUB_EVENT_PATH" 2>/dev/null || echo "")
     if [ -z "$base_sha" ]; then base_sha=$(git rev-parse "origin/$GITHUB_BASE_REF" 2>/dev/null || echo "$GITHUB_BASE_REF"); fi
-    free_review_url="https://www.oasdiff.com/review?owner=${owner}&repo=${repo}&base_sha=$(urlencode "$base_sha")&rev_sha=${head_sha}&base_file=$(urlencode "$base_path")&rev_file=$(urlencode "$rev_path")"
+    free_review_url="https://www.oasdiff.com/review?owner=${owner}&repo=${repo}&base_sha=$(urlencode "$base_sha")&rev_sha=${head_sha}&base_file=$(urlencode "$base_path")&rev_file=$(urlencode "$rev_path")&action_version=$(urlencode "${GITHUB_ACTION_REF:-unknown}")"
     echo "::notice::📋 Review & approve these API changes → ${free_review_url}"
     # The Step Summary surfaces both the link (for visitors who'd rather use
     # the web UI) and the CLI command itself (for visitors who recognize it

--- a/pr-comment/entrypoint.sh
+++ b/pr-comment/entrypoint.sh
@@ -125,7 +125,7 @@ if [ -n "$base_sha" ]; then
 else
     free_base_sha=$(git rev-parse "origin/$GITHUB_BASE_REF" 2>/dev/null || echo "$GITHUB_BASE_REF")
 fi
-free_review_url="https://www.oasdiff.com/review?owner=${owner}&repo=${repo}&base_sha=$(urlencode "$free_base_sha")&rev_sha=${head_sha}&base_file=$(urlencode "$base_path")&rev_file=$(urlencode "$rev_path")"
+free_review_url="https://www.oasdiff.com/review?owner=${owner}&repo=${repo}&base_sha=$(urlencode "$free_base_sha")&rev_sha=${head_sha}&base_file=$(urlencode "$base_path")&rev_file=$(urlencode "$rev_path")&action_version=$(urlencode "${GITHUB_ACTION_REF:-unknown}")"
 echo "::notice::📋 View API changes → ${free_review_url}"
 
 # Build the JSON payload. The `changes` array can be very large for
@@ -166,6 +166,7 @@ fi
 response=$(printf '%s' "$payload" | curl -s -w "\n%{http_code}" -X POST \
     "${service_url}/tenants/${oasdiff_token}/pr-comment" \
     -H "Content-Type: application/json" \
+    -H "User-Agent: oasdiff-action/${GITHUB_ACTION_REF:-unknown}" \
     --data-binary @-)
 
 http_code=$(echo "$response" | tail -1)

--- a/verify/entrypoint.sh
+++ b/verify/entrypoint.sh
@@ -77,6 +77,7 @@ payload=$(jq -nc \
 response=$(printf '%s' "$payload" | curl -s -w "\n%{http_code}" -X POST \
     "${service_url}/tenants/${oasdiff_token}/verify" \
     -H "Content-Type: application/json" \
+    -H "User-Agent: oasdiff-action/${GITHUB_ACTION_REF:-unknown}" \
     --data-binary @-)
 http_code=$(echo "$response" | tail -1)
 body=$(echo "$response" | sed '$d')


### PR DESCRIPTION
## Why

When a run misbehaves (e.g. a `/review` URL carrying a mutable `base_sha=main`, which is the pre-#117 shape), we currently can't tell from the logs which action version produced it. This adds the version to the log signal so stuck or odd behavior can be correlated with an outdated pinned version.

## What

- **Service-calling actions (`pr-comment`, `verify`)** now send `User-Agent: oasdiff-action/<ref>` on their POST to the service. Cloud Run already records the User-Agent, so this surfaces the version with **no service-side change**: a log line that read `curl 8.x` now reads `oasdiff-action/v0.0.54`.
- **Free actions (`breaking`, `changelog`) and `pr-comment`** append `action_version=<ref>` to the emitted `/review` URL, so w3's request log carries the version for the free cohort that never calls the service. The `/review` page ignores the extra query param.

`<ref>` is `GITHUB_ACTION_REF` (the tag, branch, or SHA the user pinned), falling back to `unknown`. A *missing* `action_version` on a `/review` hit is itself signal: the run is older than this change.

No behavior change for users; logging only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)