### PR TITLE
Bump base image to oasdiff v1.18.4

### DIFF
--- a/breaking/Dockerfile
+++ b/breaking/Dockerfile
@@ -1,4 +1,4 @@
-FROM tufin/oasdiff:v1.18.3
+FROM tufin/oasdiff:v1.18.4
 RUN apk add --no-cache jq
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh

--- a/changelog/Dockerfile
+++ b/changelog/Dockerfile
@@ -1,4 +1,4 @@
-FROM tufin/oasdiff:v1.18.3
+FROM tufin/oasdiff:v1.18.4
 RUN apk add --no-cache jq
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh

--- a/diff/Dockerfile
+++ b/diff/Dockerfile
@@ -1,4 +1,4 @@
-FROM tufin/oasdiff:v1.18.3
+FROM tufin/oasdiff:v1.18.4
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/pr-comment/Dockerfile
+++ b/pr-comment/Dockerfile
@@ -1,4 +1,4 @@
-FROM tufin/oasdiff:v1.18.3
+FROM tufin/oasdiff:v1.18.4
 RUN apk add --no-cache curl jq
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh

--- a/validate/Dockerfile
+++ b/validate/Dockerfile
@@ -1,4 +1,4 @@
-FROM tufin/oasdiff:v1.18.3
+FROM tufin/oasdiff:v1.18.4
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/verify/Dockerfile
+++ b/verify/Dockerfile
@@ -1,4 +1,4 @@
-FROM tufin/oasdiff:v1.18.1
+FROM tufin/oasdiff:v1.18.4
 RUN apk add --no-cache curl jq
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
Bumps every action's base image from `tufin/oasdiff:v1.18.3` (and `verify/` from `v1.18.1`) to `tufin/oasdiff:v1.18.4`.

This picks up oasdiff #990: on the git-revision load path, when a `<sha>:<path>` source names a commit not present in the local clone, oasdiff now prints the exact `git fetch origin <sha>` to run instead of a terse git error (and never mutates the repo itself). That makes the local-review command the `breaking`/`changelog` actions print self-recovering for reviewers on a fresh or shallow clone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)