### PR TITLE
Thin the free step summary to a link; add workflow param; drop the notice

### DIFF
--- a/breaking/entrypoint.sh
+++ b/breaking/entrypoint.sh
@@ -153,17 +153,13 @@ if [ -n "$breaking_changes" ] && ! echo "$breaking_changes" | head -n 1 | grep -
     base_sha=$(jq -r '.pull_request.base.sha // empty' "$GITHUB_EVENT_PATH" 2>/dev/null || echo "")
     if [ -z "$base_sha" ]; then base_sha=$(git rev-parse "origin/$GITHUB_BASE_REF" 2>/dev/null || echo "$GITHUB_BASE_REF"); fi
     # GITHUB_WORKFLOW_REF is "<owner>/<repo>/.github/workflows/<file>@<ref>";
-    # strip the repo prefix and the @ref suffix to get just the workflow file
-    # path, so the /review page can deep-link the exact file to bump the pin.
+    # strip the repo prefix and the @ref suffix to get the workflow file path.
     wf_path="${GITHUB_WORKFLOW_REF#"$GITHUB_REPOSITORY"/}"
     wf_path="${wf_path%@*}"
     free_review_url="https://www.oasdiff.com/review?owner=${owner}&repo=${repo}&base_sha=$(urlencode "$base_sha")&rev_sha=${head_sha}&base_file=$(urlencode "$base_path")&rev_file=$(urlencode "$rev_path")&action_version=$(urlencode "${GITHUB_ACTION_REF:-unknown}")"
     [ -n "$wf_path" ] && free_review_url="${free_review_url}&workflow=$(urlencode "$wf_path")"
-    # Thin step summary: a single link to the /review page, which renders the
-    # command, install help, and any upgrade nudge. Keeping that content on the
-    # page (server-controlled) rather than baking it here means we can improve it
-    # without shipping a new action version that every user has to upgrade to.
-    # The per-change ::error:: annotations above remain the inline CI signal.
+    # Step summary: a link to the /review page, which shows how to view these
+    # changes side by side.
     {
         echo "### 📋 [View these breaking changes in a side-by-side review](${free_review_url})"
     } >> "$GITHUB_STEP_SUMMARY"

--- a/breaking/entrypoint.sh
+++ b/breaking/entrypoint.sh
@@ -152,22 +152,20 @@ if [ -n "$breaking_changes" ] && ! echo "$breaking_changes" | head -n 1 | grep -
     # commit where the file lives at a different path.
     base_sha=$(jq -r '.pull_request.base.sha // empty' "$GITHUB_EVENT_PATH" 2>/dev/null || echo "")
     if [ -z "$base_sha" ]; then base_sha=$(git rev-parse "origin/$GITHUB_BASE_REF" 2>/dev/null || echo "$GITHUB_BASE_REF"); fi
+    # GITHUB_WORKFLOW_REF is "<owner>/<repo>/.github/workflows/<file>@<ref>";
+    # strip the repo prefix and the @ref suffix to get just the workflow file
+    # path, so the /review page can deep-link the exact file to bump the pin.
+    wf_path="${GITHUB_WORKFLOW_REF#"$GITHUB_REPOSITORY"/}"
+    wf_path="${wf_path%@*}"
     free_review_url="https://www.oasdiff.com/review?owner=${owner}&repo=${repo}&base_sha=$(urlencode "$base_sha")&rev_sha=${head_sha}&base_file=$(urlencode "$base_path")&rev_file=$(urlencode "$rev_path")&action_version=$(urlencode "${GITHUB_ACTION_REF:-unknown}")"
-    echo "::notice::📋 Review & approve these breaking changes → ${free_review_url}"
-    # The Step Summary surfaces both the link (for visitors who'd rather use
-    # the web UI) and the CLI command itself (for visitors who recognize it
-    # and want to skip the instruction-page detour). GitHub renders the
-    # fenced code block with a built-in copy button, so the one-step path
-    # for the familiar-visitor cohort is: scroll to the Checks tab, click
-    # copy on the command, paste into a terminal in the local clone, run.
+    [ -n "$wf_path" ] && free_review_url="${free_review_url}&workflow=$(urlencode "$wf_path")"
+    # Thin step summary: a single link to the /review page, which renders the
+    # command, install help, and any upgrade nudge. Keeping that content on the
+    # page (server-controlled) rather than baking it here means we can improve it
+    # without shipping a new action version that every user has to upgrade to.
+    # The per-change ::error:: annotations above remain the inline CI signal.
     {
-        echo "### 📋 [Review & approve these breaking changes](${free_review_url})"
-        echo ""
-        echo "Or run locally in your clone of \`${repo}\`:"
-        echo ""
-        echo '```bash'
-        echo "git fetch origin ${base_sha} ${head_sha} && oasdiff breaking ${base_sha}:${base_path} ${head_sha}:${rev_path} --open"
-        echo '```'
+        echo "### 📋 [View these breaking changes in a side-by-side review](${free_review_url})"
     } >> "$GITHUB_STEP_SUMMARY"
 else
     write_output "No breaking changes"

--- a/changelog/entrypoint.sh
+++ b/changelog/entrypoint.sh
@@ -148,16 +148,13 @@ if [ -n "$output" ] && ! echo "$output" | head -n 1 | grep -q "^No "; then
     base_sha=$(jq -r '.pull_request.base.sha // empty' "$GITHUB_EVENT_PATH" 2>/dev/null || echo "")
     if [ -z "$base_sha" ]; then base_sha=$(git rev-parse "origin/$GITHUB_BASE_REF" 2>/dev/null || echo "$GITHUB_BASE_REF"); fi
     # GITHUB_WORKFLOW_REF is "<owner>/<repo>/.github/workflows/<file>@<ref>";
-    # strip the repo prefix and the @ref suffix to get just the workflow file
-    # path, so the /review page can deep-link the exact file to bump the pin.
+    # strip the repo prefix and the @ref suffix to get the workflow file path.
     wf_path="${GITHUB_WORKFLOW_REF#"$GITHUB_REPOSITORY"/}"
     wf_path="${wf_path%@*}"
     free_review_url="https://www.oasdiff.com/review?owner=${owner}&repo=${repo}&base_sha=$(urlencode "$base_sha")&rev_sha=${head_sha}&base_file=$(urlencode "$base_path")&rev_file=$(urlencode "$rev_path")&action_version=$(urlencode "${GITHUB_ACTION_REF:-unknown}")"
     [ -n "$wf_path" ] && free_review_url="${free_review_url}&workflow=$(urlencode "$wf_path")"
-    # Thin step summary: a single link to the /review page, which renders the
-    # command, install help, and any upgrade nudge. Keeping that content on the
-    # page (server-controlled) rather than baking it here means we can improve it
-    # without shipping a new action version that every user has to upgrade to.
+    # Step summary: a link to the /review page, which shows how to view these
+    # changes side by side.
     {
         echo "### 📋 [View these API changes in a side-by-side review](${free_review_url})"
     } >> "$GITHUB_STEP_SUMMARY"

--- a/changelog/entrypoint.sh
+++ b/changelog/entrypoint.sh
@@ -147,20 +147,19 @@ if [ -n "$output" ] && ! echo "$output" | head -n 1 | grep -q "^No "; then
     # commit where the file lives at a different path.
     base_sha=$(jq -r '.pull_request.base.sha // empty' "$GITHUB_EVENT_PATH" 2>/dev/null || echo "")
     if [ -z "$base_sha" ]; then base_sha=$(git rev-parse "origin/$GITHUB_BASE_REF" 2>/dev/null || echo "$GITHUB_BASE_REF"); fi
+    # GITHUB_WORKFLOW_REF is "<owner>/<repo>/.github/workflows/<file>@<ref>";
+    # strip the repo prefix and the @ref suffix to get just the workflow file
+    # path, so the /review page can deep-link the exact file to bump the pin.
+    wf_path="${GITHUB_WORKFLOW_REF#"$GITHUB_REPOSITORY"/}"
+    wf_path="${wf_path%@*}"
     free_review_url="https://www.oasdiff.com/review?owner=${owner}&repo=${repo}&base_sha=$(urlencode "$base_sha")&rev_sha=${head_sha}&base_file=$(urlencode "$base_path")&rev_file=$(urlencode "$rev_path")&action_version=$(urlencode "${GITHUB_ACTION_REF:-unknown}")"
-    echo "::notice::📋 Review & approve these API changes → ${free_review_url}"
-    # The Step Summary surfaces both the link (for visitors who'd rather use
-    # the web UI) and the CLI command itself (for visitors who recognize it
-    # and want to skip the instruction-page detour). GitHub renders the
-    # fenced code block with a built-in copy button.
+    [ -n "$wf_path" ] && free_review_url="${free_review_url}&workflow=$(urlencode "$wf_path")"
+    # Thin step summary: a single link to the /review page, which renders the
+    # command, install help, and any upgrade nudge. Keeping that content on the
+    # page (server-controlled) rather than baking it here means we can improve it
+    # without shipping a new action version that every user has to upgrade to.
     {
-        echo "### 📋 [Review & approve these API changes](${free_review_url})"
-        echo ""
-        echo "Or run locally in your clone of \`${repo}\`:"
-        echo ""
-        echo '```bash'
-        echo "git fetch origin ${base_sha} ${head_sha} && oasdiff changelog ${base_sha}:${base_path} ${head_sha}:${rev_path} --open"
-        echo '```'
+        echo "### 📋 [View these API changes in a side-by-side review](${free_review_url})"
     } >> "$GITHUB_STEP_SUMMARY"
 else
     write_output "No changelog changes"


### PR DESCRIPTION
Moves the volatile free-review content off the **frozen, version-pinned action** and onto the `/review` page we deploy. The lesson from the missing-`git fetch` bug this spring: anything baked into the action is stuck at whatever version a user pinned, so a fix has to be released *and* every user has to upgrade. Content on the page is fixed for everyone instantly.

## Changes (breaking + changelog free actions)
- **Step summary is now a single link** to the `/review` page (retitled "View these … changes in a side-by-side review", dropping the "approve" framing free can't deliver). No baked command. The page renders the command, install help, and any upgrade nudge.
- **Dropped the `::notice::` review link.** It isn't clickable in GitHub annotations and only duplicated the summary. The per-change `::error::` annotations remain the inline CI signal.
- **Added a `workflow` param** derived from `GITHUB_WORKFLOW_REF` (the exact `.github/workflows/<file>` path), so the page can deep-link the workflow file to bump the action pin. Links from older actions that don't send it fall back to the `.github/workflows` folder (handled page-side).

## Compatibility
Pure additive on the URL (`&workflow=…`); the page validates/ignores it and falls back gracefully. The Pro `pr-comment` action and its notice are untouched. `review_url` output shape is unchanged except the appended param, so the existing URL-shape tests still hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)