### PR TITLE
docs: bump action examples to v0.0.55

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - run: git fetch --depth=1 origin ${{ github.base_ref }}
-      - uses: oasdiff/oasdiff-action/breaking@v0.0.54
+      - uses: oasdiff/oasdiff-action/breaking@v0.0.55
         with:
           base: 'origin/${{ github.base_ref }}:openapi.yaml'
           revision: 'HEAD:openapi.yaml'
@@ -67,7 +67,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - run: git fetch --depth=1 origin ${{ github.base_ref }}
-      - uses: oasdiff/oasdiff-action/breaking@v0.0.54
+      - uses: oasdiff/oasdiff-action/breaking@v0.0.55
         with:
           base: 'origin/${{ github.base_ref }}:openapi.yaml'
           revision: 'HEAD:openapi.yaml'
@@ -107,7 +107,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - run: git fetch --depth=1 origin ${{ github.base_ref }}
-      - uses: oasdiff/oasdiff-action/changelog@v0.0.54
+      - uses: oasdiff/oasdiff-action/changelog@v0.0.55
         with:
           base: 'origin/${{ github.base_ref }}:openapi.yaml'
           revision: 'HEAD:openapi.yaml'
@@ -146,7 +146,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - run: git fetch --depth=1 origin ${{ github.base_ref }}
-      - uses: oasdiff/oasdiff-action/diff@v0.0.54
+      - uses: oasdiff/oasdiff-action/diff@v0.0.55
         with:
           base: 'origin/${{ github.base_ref }}:openapi.yaml'
           revision: 'HEAD:openapi.yaml'
@@ -180,7 +180,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: oasdiff/oasdiff-action/validate@v0.0.54
+      - uses: oasdiff/oasdiff-action/validate@v0.0.55
         with:
           spec: 'openapi.yaml'
 ```
@@ -220,7 +220,7 @@ The actions read this file from the runner's `$GITHUB_WORKSPACE` (which `actions
 **Explicit path**: if your config lives somewhere else, set `OASDIFF_CONFIG` in the workflow `env:` to point at it:
 
 ```yaml
-- uses: oasdiff/oasdiff-action/breaking@v0.0.54
+- uses: oasdiff/oasdiff-action/breaking@v0.0.55
   env:
     OASDIFF_CONFIG: ./config/oasdiff.yaml
   with:
@@ -272,7 +272,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - run: git fetch --depth=1 origin ${{ github.base_ref }}
-      - uses: oasdiff/oasdiff-action/pr-comment@v0.0.54
+      - uses: oasdiff/oasdiff-action/pr-comment@v0.0.55
         with:
           base: 'origin/${{ github.base_ref }}:openapi.yaml'
           revision: 'HEAD:openapi.yaml'
@@ -320,7 +320,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - run: git fetch --depth=1 origin ${{ github.base_ref }}
-      - uses: oasdiff/oasdiff-action/pr-comment@v0.0.54
+      - uses: oasdiff/oasdiff-action/pr-comment@v0.0.55
         with:
           base: 'origin/${{ github.base_ref }}:openapi.yaml'
           revision: 'HEAD:openapi.yaml'
@@ -331,7 +331,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - run: git fetch --depth=1 origin ${{ github.event.repository.default_branch }}
-      - uses: oasdiff/oasdiff-action/verify@v0.0.54
+      - uses: oasdiff/oasdiff-action/verify@v0.0.55
         with:
           base: 'origin/${{ github.event.repository.default_branch }}:openapi.yaml'
           revision: 'HEAD:openapi.yaml'


### PR DESCRIPTION
Point all README examples at the upcoming v0.0.55 release (thinned step summary + workflow param).