### PR TITLE
Pass the PR base branch in the review URL (editable workflow link)

### DIFF
--- a/breaking/entrypoint.sh
+++ b/breaking/entrypoint.sh
@@ -158,6 +158,9 @@ if [ -n "$breaking_changes" ] && ! echo "$breaking_changes" | head -n 1 | grep -
     wf_path="${wf_path%@*}"
     free_review_url="https://www.oasdiff.com/review?owner=${owner}&repo=${repo}&base_sha=$(urlencode "$base_sha")&rev_sha=${head_sha}&base_file=$(urlencode "$base_path")&rev_file=$(urlencode "$rev_path")&action_version=$(urlencode "${GITHUB_ACTION_REF:-unknown}")"
     [ -n "$wf_path" ] && free_review_url="${free_review_url}&workflow=$(urlencode "$wf_path")"
+    # The PR base branch is where the workflow file lives; pass it so the page
+    # can deep-link the editable file (/edit/<branch>/<path>).
+    [ -n "$GITHUB_BASE_REF" ] && free_review_url="${free_review_url}&branch=$(urlencode "$GITHUB_BASE_REF")"
     # Step summary: a link to the /review page, which shows how to view these
     # changes side by side.
     {

--- a/changelog/entrypoint.sh
+++ b/changelog/entrypoint.sh
@@ -153,6 +153,9 @@ if [ -n "$output" ] && ! echo "$output" | head -n 1 | grep -q "^No "; then
     wf_path="${wf_path%@*}"
     free_review_url="https://www.oasdiff.com/review?owner=${owner}&repo=${repo}&base_sha=$(urlencode "$base_sha")&rev_sha=${head_sha}&base_file=$(urlencode "$base_path")&rev_file=$(urlencode "$rev_path")&action_version=$(urlencode "${GITHUB_ACTION_REF:-unknown}")"
     [ -n "$wf_path" ] && free_review_url="${free_review_url}&workflow=$(urlencode "$wf_path")"
+    # The PR base branch is where the workflow file lives; pass it so the page
+    # can deep-link the editable file (/edit/<branch>/<path>).
+    [ -n "$GITHUB_BASE_REF" ] && free_review_url="${free_review_url}&branch=$(urlencode "$GITHUB_BASE_REF")"
     # Step summary: a link to the /review page, which shows how to view these
     # changes side by side.
     {


### PR DESCRIPTION
Adds `&branch=<GITHUB_BASE_REF>` to the free `breaking`/`changelog` review URL. The base branch is where the workflow file lives, so the /review page can build an editable `/edit/<branch>/<path>` link (GitHub's edit route needs a real branch; `/edit/HEAD` 404s). Pure additive param; the page falls back to the workflows folder when it's absent.