### PR TITLE
bump: oasdiff v1.18.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - run: git fetch --depth=1 origin ${{ github.base_ref }}
-      - uses: oasdiff/oasdiff-action/breaking@v0.0.56
+      - uses: oasdiff/oasdiff-action/breaking@v0.0.57
         with:
           base: 'origin/${{ github.base_ref }}:openapi.yaml'
           revision: 'HEAD:openapi.yaml'
@@ -67,7 +67,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - run: git fetch --depth=1 origin ${{ github.base_ref }}
-      - uses: oasdiff/oasdiff-action/breaking@v0.0.56
+      - uses: oasdiff/oasdiff-action/breaking@v0.0.57
         with:
           base: 'origin/${{ github.base_ref }}:openapi.yaml'
           revision: 'HEAD:openapi.yaml'
@@ -107,7 +107,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - run: git fetch --depth=1 origin ${{ github.base_ref }}
-      - uses: oasdiff/oasdiff-action/changelog@v0.0.56
+      - uses: oasdiff/oasdiff-action/changelog@v0.0.57
         with:
           base: 'origin/${{ github.base_ref }}:openapi.yaml'
           revision: 'HEAD:openapi.yaml'
@@ -146,7 +146,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - run: git fetch --depth=1 origin ${{ github.base_ref }}
-      - uses: oasdiff/oasdiff-action/diff@v0.0.56
+      - uses: oasdiff/oasdiff-action/diff@v0.0.57
         with:
           base: 'origin/${{ github.base_ref }}:openapi.yaml'
           revision: 'HEAD:openapi.yaml'
@@ -180,7 +180,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: oasdiff/oasdiff-action/validate@v0.0.56
+      - uses: oasdiff/oasdiff-action/validate@v0.0.57
         with:
           spec: 'openapi.yaml'
 ```
@@ -220,7 +220,7 @@ The actions read this file from the runner's `$GITHUB_WORKSPACE` (which `actions
 **Explicit path**: if your config lives somewhere else, set `OASDIFF_CONFIG` in the workflow `env:` to point at it:
 
 ```yaml
-- uses: oasdiff/oasdiff-action/breaking@v0.0.56
+- uses: oasdiff/oasdiff-action/breaking@v0.0.57
   env:
     OASDIFF_CONFIG: ./config/oasdiff.yaml
   with:
@@ -272,7 +272,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - run: git fetch --depth=1 origin ${{ github.base_ref }}
-      - uses: oasdiff/oasdiff-action/pr-comment@v0.0.56
+      - uses: oasdiff/oasdiff-action/pr-comment@v0.0.57
         with:
           base: 'origin/${{ github.base_ref }}:openapi.yaml'
           revision: 'HEAD:openapi.yaml'
@@ -320,7 +320,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - run: git fetch --depth=1 origin ${{ github.base_ref }}
-      - uses: oasdiff/oasdiff-action/pr-comment@v0.0.56
+      - uses: oasdiff/oasdiff-action/pr-comment@v0.0.57
         with:
           base: 'origin/${{ github.base_ref }}:openapi.yaml'
           revision: 'HEAD:openapi.yaml'
@@ -331,7 +331,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - run: git fetch --depth=1 origin ${{ github.event.repository.default_branch }}
-      - uses: oasdiff/oasdiff-action/verify@v0.0.56
+      - uses: oasdiff/oasdiff-action/verify@v0.0.57
         with:
           base: 'origin/${{ github.event.repository.default_branch }}:openapi.yaml'
           revision: 'HEAD:openapi.yaml'

--- a/breaking/Dockerfile
+++ b/breaking/Dockerfile
@@ -1,4 +1,4 @@
-FROM tufin/oasdiff:v1.18.4
+FROM tufin/oasdiff:v1.18.5
 RUN apk add --no-cache jq
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh

--- a/changelog/Dockerfile
+++ b/changelog/Dockerfile
@@ -1,4 +1,4 @@
-FROM tufin/oasdiff:v1.18.4
+FROM tufin/oasdiff:v1.18.5
 RUN apk add --no-cache jq
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh

--- a/diff/Dockerfile
+++ b/diff/Dockerfile
@@ -1,4 +1,4 @@
-FROM tufin/oasdiff:v1.18.4
+FROM tufin/oasdiff:v1.18.5
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/pr-comment/Dockerfile
+++ b/pr-comment/Dockerfile
@@ -1,4 +1,4 @@
-FROM tufin/oasdiff:v1.18.4
+FROM tufin/oasdiff:v1.18.5
 RUN apk add --no-cache curl jq
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh

--- a/validate/Dockerfile
+++ b/validate/Dockerfile
@@ -1,4 +1,4 @@
-FROM tufin/oasdiff:v1.18.4
+FROM tufin/oasdiff:v1.18.5
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Bumps the action base image to oasdiff v1.18.5 (checker panic fix + 400-on-bad-spec). Triggered by the oasdiff v1.18.5 release. After merge, release the action as v0.0.57.