### PR TITLE
feat: stamp base_kind/rev_kind on the /review link

### DIFF
--- a/breaking/entrypoint.sh
+++ b/breaking/entrypoint.sh
@@ -140,6 +140,19 @@ if [ -n "$breaking_changes" ] && ! echo "$breaking_changes" | head -n 1 | grep -
     }
     base_path=$(strip_ref_prefix "$base")
     rev_path=$(strip_ref_prefix "$revision")
+    # Classify each source so the /review page gives exact guidance instead of
+    # guessing: a URL, a git ref (ref:path), or a local file (e.g. a generated
+    # baseline that isn't committed). The page can't tell these apart from the
+    # stripped path alone.
+    classify_kind() {
+        case "$1" in
+            http://*|https://*) printf 'url' ;;
+            *:*)                printf 'gitref' ;;
+            *)                  printf 'file' ;;
+        esac
+    }
+    base_kind=$(classify_kind "$base")
+    rev_kind=$(classify_kind "$revision")
     owner="${GITHUB_REPOSITORY%%/*}"
     repo="${GITHUB_REPOSITORY#*/}"
     head_sha=$(jq -r '.pull_request.head.sha // empty' "$GITHUB_EVENT_PATH" 2>/dev/null || echo "")
@@ -156,7 +169,7 @@ if [ -n "$breaking_changes" ] && ! echo "$breaking_changes" | head -n 1 | grep -
     # strip the repo prefix and the @ref suffix to get the workflow file path.
     wf_path="${GITHUB_WORKFLOW_REF#"$GITHUB_REPOSITORY"/}"
     wf_path="${wf_path%@*}"
-    free_review_url="https://www.oasdiff.com/review?owner=${owner}&repo=${repo}&base_sha=$(urlencode "$base_sha")&rev_sha=${head_sha}&base_file=$(urlencode "$base_path")&rev_file=$(urlencode "$rev_path")&action_version=$(urlencode "${GITHUB_ACTION_REF:-unknown}")"
+    free_review_url="https://www.oasdiff.com/review?owner=${owner}&repo=${repo}&base_sha=$(urlencode "$base_sha")&rev_sha=${head_sha}&base_file=$(urlencode "$base_path")&rev_file=$(urlencode "$rev_path")&base_kind=${base_kind}&rev_kind=${rev_kind}&action_version=$(urlencode "${GITHUB_ACTION_REF:-unknown}")"
     [ -n "$wf_path" ] && free_review_url="${free_review_url}&workflow=$(urlencode "$wf_path")"
     # The PR base branch is where the workflow file lives; pass it so the page
     # can deep-link the editable file (/edit/<branch>/<path>).

--- a/changelog/entrypoint.sh
+++ b/changelog/entrypoint.sh
@@ -135,6 +135,19 @@ if [ -n "$output" ] && ! echo "$output" | head -n 1 | grep -q "^No "; then
     }
     base_path=$(strip_ref_prefix "$base")
     rev_path=$(strip_ref_prefix "$revision")
+    # Classify each source so the /review page gives exact guidance instead of
+    # guessing: a URL, a git ref (ref:path), or a local file (e.g. a generated
+    # baseline that isn't committed). The page can't tell these apart from the
+    # stripped path alone.
+    classify_kind() {
+        case "$1" in
+            http://*|https://*) printf 'url' ;;
+            *:*)                printf 'gitref' ;;
+            *)                  printf 'file' ;;
+        esac
+    }
+    base_kind=$(classify_kind "$base")
+    rev_kind=$(classify_kind "$revision")
     owner="${GITHUB_REPOSITORY%%/*}"
     repo="${GITHUB_REPOSITORY#*/}"
     head_sha=$(jq -r '.pull_request.head.sha // empty' "$GITHUB_EVENT_PATH" 2>/dev/null || echo "")
@@ -151,7 +164,7 @@ if [ -n "$output" ] && ! echo "$output" | head -n 1 | grep -q "^No "; then
     # strip the repo prefix and the @ref suffix to get the workflow file path.
     wf_path="${GITHUB_WORKFLOW_REF#"$GITHUB_REPOSITORY"/}"
     wf_path="${wf_path%@*}"
-    free_review_url="https://www.oasdiff.com/review?owner=${owner}&repo=${repo}&base_sha=$(urlencode "$base_sha")&rev_sha=${head_sha}&base_file=$(urlencode "$base_path")&rev_file=$(urlencode "$rev_path")&action_version=$(urlencode "${GITHUB_ACTION_REF:-unknown}")"
+    free_review_url="https://www.oasdiff.com/review?owner=${owner}&repo=${repo}&base_sha=$(urlencode "$base_sha")&rev_sha=${head_sha}&base_file=$(urlencode "$base_path")&rev_file=$(urlencode "$rev_path")&base_kind=${base_kind}&rev_kind=${rev_kind}&action_version=$(urlencode "${GITHUB_ACTION_REF:-unknown}")"
     [ -n "$wf_path" ] && free_review_url="${free_review_url}&workflow=$(urlencode "$wf_path")"
     # The PR base branch is where the workflow file lives; pass it so the page
     # can deep-link the editable file (/edit/<branch>/<path>).

--- a/pr-comment/entrypoint.sh
+++ b/pr-comment/entrypoint.sh
@@ -115,6 +115,19 @@ strip_ref_prefix() {
 }
 base_path=$(strip_ref_prefix "$base")
 rev_path=$(strip_ref_prefix "$revision")
+# Classify each source so the /review page gives exact guidance instead of
+# guessing: a URL, a git ref (ref:path), or a local file (e.g. a generated
+# baseline that isn't committed). The page can't tell these apart from the
+# stripped path alone.
+classify_kind() {
+    case "$1" in
+        http://*|https://*) printf 'url' ;;
+        *:*)                printf 'gitref' ;;
+        *)                  printf 'file' ;;
+    esac
+}
+base_kind=$(classify_kind "$base")
+rev_kind=$(classify_kind "$revision")
 # Prefer the base SHA over the branch name so the link is commit-pinned.
 # Fall back through `git rev-parse origin/<branch>` before resorting to
 # the branch name itself, so push-event triggers (no pull_request payload)
@@ -125,7 +138,7 @@ if [ -n "$base_sha" ]; then
 else
     free_base_sha=$(git rev-parse "origin/$GITHUB_BASE_REF" 2>/dev/null || echo "$GITHUB_BASE_REF")
 fi
-free_review_url="https://www.oasdiff.com/review?owner=${owner}&repo=${repo}&base_sha=$(urlencode "$free_base_sha")&rev_sha=${head_sha}&base_file=$(urlencode "$base_path")&rev_file=$(urlencode "$rev_path")&action_version=$(urlencode "${GITHUB_ACTION_REF:-unknown}")"
+free_review_url="https://www.oasdiff.com/review?owner=${owner}&repo=${repo}&base_sha=$(urlencode "$free_base_sha")&rev_sha=${head_sha}&base_file=$(urlencode "$base_path")&rev_file=$(urlencode "$rev_path")&base_kind=${base_kind}&rev_kind=${rev_kind}&action_version=$(urlencode "${GITHUB_ACTION_REF:-unknown}")"
 echo "::notice::📋 View API changes → ${free_review_url}"
 
 # Build the JSON payload. The `changes` array can be very large for


### PR DESCRIPTION
## What

Adds `base_kind` / `rev_kind` (`url` | `gitref` | `file`) to the `/review` link emitted by the `breaking`, `changelog`, and `pr-comment` actions.

## Why

The `/review` page reconstructs guidance from the link params, but the action **strips the source kind**: `strip_ref_prefix` turns `main:openapi.yaml` (a git ref) and `base-bundled.yaml` (a generated local file) both into a bare path. The page then can't tell a committed spec from a CI-generated one, and guessed wrong for the dominant "generate a base copy and diff it" workflow (~⅔ of real traffic).

The action already knows the kind — it's the shape of the `base`/`revision` input, exactly what `strip_ref_prefix` branches on. So stamp it:

```sh
classify_kind() {
    case "$1" in
        http://*|https://*) printf 'url' ;;
        *:*)                printf 'gitref' ;;
        *)                  printf 'file' ;;
    esac
}
```

With this, the page gives **exact** per-source guidance (committed → `commit:path` + a resolving GitHub link; generated → reproduce it the way your workflow does; URL → use it directly) instead of a generic three-case guide. (w3 consumes this in a companion PR and falls back to the generic guide for links emitted before this release.)

## Notes

- Append-only query params; no behavior change to existing params.
- `bash -n` clean on all three entrypoints; classification verified against real-world inputs (`main:openapi.yaml`→gitref, `https://…`→url, `base-bundled.yaml`/`out/base_ref_swagger/…`→file).
- Takes effect for links emitted after the next action release; older links omit the params and the page handles that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)