### PR TITLE
Post the free review link as a PR comment (fallback to job summary)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ name: oasdiff
 on:
   pull_request:
     branches: [ "main" ]
+permissions:
+  contents: read
+  pull-requests: write   # lets the action post the review link as a PR comment
 jobs:
   breaking-changes:
     runs-on: ubuntu-latest
@@ -42,9 +45,10 @@ jobs:
           base: 'origin/${{ github.base_ref }}:openapi.yaml'
           revision: 'HEAD:openapi.yaml'
           fail-on: WARN
+          github-token: ${{ github.token }}
 ```
 
-This compares your spec on the PR branch against the base branch and fails the workflow if any breaking changes are found.
+This compares your spec on the PR branch against the base branch and fails the workflow if any breaking changes are found. When changes are found it posts a side-by-side review link as a PR comment; drop `github-token` and the `pull-requests: write` permission to keep that link in the job summary instead.
 
 ---
 
@@ -54,13 +58,16 @@ The following actions run the oasdiff CLI directly in your GitHub runner — no 
 
 ### Check for breaking changes
 
-Detects breaking changes and writes inline `::error::` annotations on the pull request's Files changed tab. Fails the workflow when changes at or above the `fail-on` severity are found. When changes are found it also uploads the comparison and adds a link to a full side-by-side review in the job summary (the `review` input, on by default); the two specs are encrypted in CI before upload, so the server cannot read them.
+Detects breaking changes and writes inline `::error::` annotations on the pull request's Files changed tab. Fails the workflow when changes at or above the `fail-on` severity are found. When changes are found it also uploads the comparison and links to a full side-by-side review (the `review` input, on by default); the two specs are encrypted in CI before upload, so the server cannot read them. The link is posted as a pull-request comment when you pass `github-token` (and grant `pull-requests: write`); otherwise, and on fork PRs where the token is read-only, it falls back to the job summary.
 
 ```yaml
 name: oasdiff
 on:
   pull_request:
     branches: [ "main" ]
+permissions:
+  contents: read
+  pull-requests: write   # lets the action post the review link as a PR comment
 jobs:
   breaking-changes:
     runs-on: ubuntu-latest
@@ -72,6 +79,7 @@ jobs:
           base: 'origin/${{ github.base_ref }}:openapi.yaml'
           revision: 'HEAD:openapi.yaml'
           fail-on: WARN
+          github-token: ${{ github.token }}
 ```
 
 | Input | Default | Description | Accepted values |
@@ -91,17 +99,21 @@ jobs:
 | `warn-ignore` | `''` | Path to a file containing regex patterns for warning-level changes to ignore | file path |
 | `output-to-file` | `''` | Write output to this file path instead of stdout | file path |
 | `allow-external-refs` | `false` | Resolve external `$ref`s. Defaults to `false` to prevent SSRF on untrusted pull requests. Set `true` if your spec references external URLs or loads split files by file path | `true`, `false` |
-| `review` | `true` | When changes are found, upload the comparison to oasdiff.com and put a direct side-by-side review link in the job summary. The two specs are encrypted in CI before upload and the decryption key stays in the URL fragment, so the server cannot read them. Set `false` to skip the upload, so no spec leaves CI | `true`, `false` |
+| `review` | `true` | When changes are found, upload the comparison to oasdiff.com and link to a direct side-by-side review. The two specs are encrypted in CI before upload and the decryption key stays in the URL fragment, so the server cannot read them. Set `false` to skip the upload, so no spec leaves CI | `true`, `false` |
+| `github-token` | `''` | Token used to post the review link as a pull-request comment, so reviewers see it on the PR instead of only in the job summary. Pass `${{ github.token }}` and grant `permissions: pull-requests: write`. Optional; omit it to keep the link in the job summary only. Fork PRs (read-only token) fall back to the summary | `${{ github.token }}` |
 
 ### Generate a changelog
 
-Outputs all changes (breaking and non-breaking) between two specs. When changes are found it also uploads the comparison and adds a link to a full side-by-side review in the job summary (the `review` input, on by default); the two specs are encrypted in CI before upload, so the server cannot read them.
+Outputs all changes (breaking and non-breaking) between two specs. When changes are found it also uploads the comparison and links to a full side-by-side review (the `review` input, on by default); the two specs are encrypted in CI before upload, so the server cannot read them. The link is posted as a pull-request comment when you pass `github-token` (and grant `pull-requests: write`); otherwise, and on fork PRs where the token is read-only, it falls back to the job summary.
 
 ```yaml
 name: oasdiff
 on:
   pull_request:
     branches: [ "main" ]
+permissions:
+  contents: read
+  pull-requests: write   # lets the action post the review link as a PR comment
 jobs:
   changelog:
     runs-on: ubuntu-latest
@@ -112,6 +124,7 @@ jobs:
         with:
           base: 'origin/${{ github.base_ref }}:openapi.yaml'
           revision: 'HEAD:openapi.yaml'
+          github-token: ${{ github.token }}
 ```
 
 | Input | Default | Description | Accepted values |
@@ -131,7 +144,8 @@ jobs:
 | `template` | `''` | Custom Go template for output formatting | Go template string |
 | `output-to-file` | `''` | Write output to this file path instead of stdout | file path |
 | `allow-external-refs` | `false` | Resolve external `$ref`s. Defaults to `false` to prevent SSRF on untrusted pull requests. Set `true` if your spec references external URLs or loads split files by file path | `true`, `false` |
-| `review` | `true` | When changes are found, upload the comparison to oasdiff.com and put a direct side-by-side review link in the job summary. The two specs are encrypted in CI before upload and the decryption key stays in the URL fragment, so the server cannot read them. Set `false` to skip the upload, so no spec leaves CI | `true`, `false` |
+| `review` | `true` | When changes are found, upload the comparison to oasdiff.com and link to a direct side-by-side review. The two specs are encrypted in CI before upload and the decryption key stays in the URL fragment, so the server cannot read them. Set `false` to skip the upload, so no spec leaves CI | `true`, `false` |
+| `github-token` | `''` | Token used to post the review link as a pull-request comment, so reviewers see it on the PR instead of only in the job summary. Pass `${{ github.token }}` and grant `permissions: pull-requests: write`. Optional; omit it to keep the link in the job summary only. Fork PRs (read-only token) fall back to the summary | `${{ github.token }}` |
 
 ### Generate a diff report
 

--- a/breaking/action.yml
+++ b/breaking/action.yml
@@ -60,6 +60,10 @@ inputs:
     description: 'Upload the comparison to oasdiff.com (encrypted, zero-knowledge) and link straight to a side-by-side review of these changes. The specs are encrypted client-side and the key stays in the URL fragment, so the server cannot read them. Set to false to skip the upload entirely, so no spec leaves CI; the change detection and inline annotations are unaffected.'
     required: false
     default: 'true'
+  github-token:
+    description: 'GitHub token used to post the review link as a pull-request comment, so reviewers see it on the PR instead of only in the job summary. Pass ${{ github.token }} and grant the job permissions: pull-requests: write. Optional; when omitted the link is written only to the job summary. On fork pull requests the token is read-only, so commenting is skipped and the link falls back to the job summary.'
+    required: false
+    default: ''
 outputs:
   breaking:
     description: 'Output summary of API breaking changes, encompassing both warnings and errors'
@@ -85,3 +89,4 @@ runs:
     - ${{ inputs.output-to-file }}
     - ${{ inputs.allow-external-refs }}
     - ${{ inputs.review }}
+    - ${{ inputs.github-token }}

--- a/breaking/action.yml
+++ b/breaking/action.yml
@@ -61,7 +61,7 @@ inputs:
     required: false
     default: 'true'
   github-token:
-    description: 'GitHub token used to post the review link as a pull-request comment, so reviewers see it on the PR instead of only in the job summary. Pass ${{ github.token }} and grant the job permissions: pull-requests: write. Optional; when omitted the link is written only to the job summary. On fork pull requests the token is read-only, so commenting is skipped and the link falls back to the job summary.'
+    description: 'GitHub token used to post the review link as a pull-request comment, so reviewers see it on the PR instead of only in the job summary. Pass the built-in github.token and grant the job permissions: pull-requests: write. Optional; when omitted the link is written only to the job summary. On fork pull requests the token is read-only, so commenting is skipped and the link falls back to the job summary.'
     required: false
     default: ''
 outputs:

--- a/breaking/entrypoint.sh
+++ b/breaking/entrypoint.sh
@@ -22,6 +22,69 @@ readonly warn_ignore="${13}"
 readonly output_to_file="${14}"
 readonly allow_external_refs="${15}"
 readonly review="${16}"
+readonly github_token="${17}"
+
+# post_review_comment posts (or updates) a single pull-request comment with the
+# free side-by-side review link, so reviewers see it on the PR rather than only
+# in the job summary (a low-traffic page most users never open). Best-effort and
+# never fatal: it needs a github-token with pull-requests:write and a
+# pull_request event. On fork pull requests GITHUB_TOKEN is read-only, so the
+# API call returns 403 and we fall back to the job summary, which is always
+# written regardless.
+#
+# $1: the review URL, or empty to mark the PR as having no breaking changes
+#     (in that case it only updates an existing comment, never creates one, so
+#     a PR that never had changes stays comment-free).
+post_review_comment () {
+    review_url="$1"
+    [ -z "$github_token" ] && return 0
+    pr_number=$(echo "$GITHUB_REF" | sed -n 's|refs/pull/\([0-9]*\)/merge|\1|p')
+    [ -z "$pr_number" ] && return 0
+    owner="${GITHUB_REPOSITORY%%/*}"
+    repo="${GITHUB_REPOSITORY#*/}"
+    api="${GITHUB_API_URL:-https://api.github.com}"
+    marker="<!-- oasdiff-free-review -->"
+
+    # Find an existing oasdiff comment to update so we don't post a fresh
+    # comment on every push.
+    existing_id=$(curl -s \
+        -H "Authorization: token $github_token" \
+        -H "Accept: application/vnd.github+json" \
+        "${api}/repos/${owner}/${repo}/issues/${pr_number}/comments?per_page=100" 2>/dev/null \
+        | jq -r --arg m "$marker" 'map(select(.body | contains($m))) | .[0].id // empty' 2>/dev/null) || existing_id=""
+
+    if [ -n "$review_url" ]; then
+        body="${marker}
+### 📋 [View the side-by-side API change review](${review_url})
+
+The two specs were encrypted in CI before upload and the decryption key stays in this link, so oasdiff cannot read them. Anyone with the link can open the review; it expires after 7 days."
+    elif [ -n "$existing_id" ]; then
+        body="${marker}
+### ✅ No breaking changes in the latest revision."
+    else
+        return 0
+    fi
+
+    payload=$(jq -n --arg body "$body" '{body: $body}')
+    if [ -n "$existing_id" ]; then
+        endpoint="${api}/repos/${owner}/${repo}/issues/comments/${existing_id}"
+        method="PATCH"
+    else
+        endpoint="${api}/repos/${owner}/${repo}/issues/${pr_number}/comments"
+        method="POST"
+    fi
+
+    code=$(printf '%s' "$payload" | curl -s -o /dev/null -w "%{http_code}" -X "$method" \
+        -H "Authorization: token $github_token" \
+        -H "Accept: application/vnd.github+json" \
+        "$endpoint" --data-binary @- 2>/dev/null) || code="000"
+
+    if [ "$code" -ge 200 ] && [ "$code" -lt 300 ]; then
+        echo "oasdiff: posted the side-by-side review link as a PR comment."
+    else
+        echo "::notice::oasdiff: couldn't post the review link as a PR comment (HTTP ${code}). On fork pull requests the token is read-only; otherwise grant 'permissions: pull-requests: write'. The link is still in the job summary."
+    fi
+}
 
 write_output () {
     local output="$1"
@@ -146,6 +209,9 @@ if [ -n "$breaking_changes" ] && ! echo "$breaking_changes" | head -n 1 | grep -
             | grep -oE 'https://[^[:space:]]+/review/e/[^[:space:]]+' | head -n 1) || true
         if [ -n "$free_review_url" ]; then
             echo "### 📋 [View these breaking changes in a side-by-side review](${free_review_url})" >> "$GITHUB_STEP_SUMMARY"
+            # Also surface the link on the PR itself (best-effort) so reviewers
+            # don't have to find the job summary.
+            post_review_comment "$free_review_url"
         else
             # review was requested but no link came back: an offline runner,
             # oasdiff.com unreachable, or an older oasdiff in the base image.
@@ -157,6 +223,11 @@ if [ -n "$breaking_changes" ] && ! echo "$breaking_changes" | head -n 1 | grep -
     fi
 else
     write_output "No breaking changes"
+    # Keep an existing review comment honest when a later push fixes the
+    # breaking changes; never create one for an always-clean PR.
+    if [ "$review" != "false" ]; then
+        post_review_comment ""
+    fi
 fi
 
 echo "$delimiter" >>"$GITHUB_OUTPUT"

--- a/changelog/action.yml
+++ b/changelog/action.yml
@@ -64,7 +64,7 @@ inputs:
     required: false
     default: 'true'
   github-token:
-    description: 'GitHub token used to post the review link as a pull-request comment, so reviewers see it on the PR instead of only in the job summary. Pass ${{ github.token }} and grant the job permissions: pull-requests: write. Optional; when omitted the link is written only to the job summary. On fork pull requests the token is read-only, so commenting is skipped and the link falls back to the job summary.'
+    description: 'GitHub token used to post the review link as a pull-request comment, so reviewers see it on the PR instead of only in the job summary. Pass the built-in github.token and grant the job permissions: pull-requests: write. Optional; when omitted the link is written only to the job summary. On fork pull requests the token is read-only, so commenting is skipped and the link falls back to the job summary.'
     required: false
     default: ''
 outputs:

--- a/changelog/action.yml
+++ b/changelog/action.yml
@@ -63,6 +63,10 @@ inputs:
     description: 'Upload the comparison to oasdiff.com (encrypted, zero-knowledge) and link straight to a side-by-side review of these changes. The specs are encrypted client-side and the key stays in the URL fragment, so the server cannot read them. Set to false to skip the upload entirely, so no spec leaves CI; the change detection and inline annotations are unaffected.'
     required: false
     default: 'true'
+  github-token:
+    description: 'GitHub token used to post the review link as a pull-request comment, so reviewers see it on the PR instead of only in the job summary. Pass ${{ github.token }} and grant the job permissions: pull-requests: write. Optional; when omitted the link is written only to the job summary. On fork pull requests the token is read-only, so commenting is skipped and the link falls back to the job summary.'
+    required: false
+    default: ''
 outputs:
   changelog:
     description: 'Output summary of API changelog'
@@ -88,4 +92,5 @@ runs:
     - ${{ inputs.level }}
     - ${{ inputs.allow-external-refs }}
     - ${{ inputs.review }}
+    - ${{ inputs.github-token }}
 

--- a/changelog/entrypoint.sh
+++ b/changelog/entrypoint.sh
@@ -41,6 +41,69 @@ readonly template="${13}"
 readonly level="${14}"
 readonly allow_external_refs="${15}"
 readonly review="${16}"
+readonly github_token="${17}"
+
+# post_review_comment posts (or updates) a single pull-request comment with the
+# free side-by-side review link, so reviewers see it on the PR rather than only
+# in the job summary (a low-traffic page most users never open). Best-effort and
+# never fatal: it needs a github-token with pull-requests:write and a
+# pull_request event. On fork pull requests GITHUB_TOKEN is read-only, so the
+# API call returns 403 and we fall back to the job summary, which is always
+# written regardless.
+#
+# $1: the review URL, or empty to mark the PR as having no changes (in that case
+#     it only updates an existing comment, never creates one, so a PR that never
+#     had changes stays comment-free).
+post_review_comment () {
+    review_url="$1"
+    [ -z "$github_token" ] && return 0
+    pr_number=$(echo "$GITHUB_REF" | sed -n 's|refs/pull/\([0-9]*\)/merge|\1|p')
+    [ -z "$pr_number" ] && return 0
+    owner="${GITHUB_REPOSITORY%%/*}"
+    repo="${GITHUB_REPOSITORY#*/}"
+    api="${GITHUB_API_URL:-https://api.github.com}"
+    marker="<!-- oasdiff-free-review -->"
+
+    # Find an existing oasdiff comment to update so we don't post a fresh
+    # comment on every push.
+    existing_id=$(curl -s \
+        -H "Authorization: token $github_token" \
+        -H "Accept: application/vnd.github+json" \
+        "${api}/repos/${owner}/${repo}/issues/${pr_number}/comments?per_page=100" 2>/dev/null \
+        | jq -r --arg m "$marker" 'map(select(.body | contains($m))) | .[0].id // empty' 2>/dev/null) || existing_id=""
+
+    if [ -n "$review_url" ]; then
+        body="${marker}
+### 📋 [View the side-by-side API change review](${review_url})
+
+The two specs were encrypted in CI before upload and the decryption key stays in this link, so oasdiff cannot read them. Anyone with the link can open the review; it expires after 7 days."
+    elif [ -n "$existing_id" ]; then
+        body="${marker}
+### ✅ No API changes in the latest revision."
+    else
+        return 0
+    fi
+
+    payload=$(jq -n --arg body "$body" '{body: $body}')
+    if [ -n "$existing_id" ]; then
+        endpoint="${api}/repos/${owner}/${repo}/issues/comments/${existing_id}"
+        method="PATCH"
+    else
+        endpoint="${api}/repos/${owner}/${repo}/issues/${pr_number}/comments"
+        method="POST"
+    fi
+
+    code=$(printf '%s' "$payload" | curl -s -o /dev/null -w "%{http_code}" -X "$method" \
+        -H "Authorization: token $github_token" \
+        -H "Accept: application/vnd.github+json" \
+        "$endpoint" --data-binary @- 2>/dev/null) || code="000"
+
+    if [ "$code" -ge 200 ] && [ "$code" -lt 300 ]; then
+        echo "oasdiff: posted the side-by-side review link as a PR comment."
+    else
+        echo "::notice::oasdiff: couldn't post the review link as a PR comment (HTTP ${code}). On fork pull requests the token is read-only; otherwise grant 'permissions: pull-requests: write'. The link is still in the job summary."
+    fi
+}
 
 echo "running oasdiff changelog base: $base, revision: $revision, include_path_params: $include_path_params, exclude_elements: $exclude_elements, filter_extension: $filter_extension, composed: $composed, flatten_allof: $flatten_allof, output_to_file: $output_to_file, prefix_base: $prefix_base, prefix_revision: $prefix_revision, case_insensitive_headers: $case_insensitive_headers, format: $format, template: $template, level: $level"
 
@@ -141,6 +204,9 @@ if [ -n "$output" ] && ! echo "$output" | head -n 1 | grep -q "^No "; then
             | grep -oE 'https://[^[:space:]]+/review/e/[^[:space:]]+' | head -n 1) || true
         if [ -n "$free_review_url" ]; then
             echo "### 📋 [View these API changes in a side-by-side review](${free_review_url})" >> "$GITHUB_STEP_SUMMARY"
+            # Also surface the link on the PR itself (best-effort) so reviewers
+            # don't have to find the job summary.
+            post_review_comment "$free_review_url"
         else
             # review was requested but no link came back: an offline runner,
             # oasdiff.com unreachable, or an older oasdiff in the base image.
@@ -152,6 +218,11 @@ if [ -n "$output" ] && ! echo "$output" | head -n 1 | grep -q "^No "; then
     fi
 else
     write_output "No changelog changes"
+    # Keep an existing review comment honest when a later push removes all
+    # changes; never create one for an always-clean PR.
+    if [ "$review" != "false" ]; then
+        post_review_comment ""
+    fi
 fi
 
 echo "$delimiter" >>"$GITHUB_OUTPUT"


### PR DESCRIPTION
The free side-by-side review link previously lived only in the **job summary**, one of the least-trafficked surfaces in GitHub Actions, so most users never saw it and the free-review giveaway under-delivered.

The `breaking` and `changelog` actions now post (and auto-update) a single **PR comment** with the review link when given a `github-token`.

## Behavior
- New optional `github-token` input. Pass `${{ github.token }}` (and grant `permissions: pull-requests: write`) to enable the comment. Omit it to keep today's behavior (link in the job summary only).
- The action posts the comment **itself, before exiting non-zero**, so it survives a `fail-on` failure (a separate workflow step would be skipped when the action step fails the gate).
- **Best-effort, never fatal:** on fork PRs `GITHUB_TOKEN` is read-only, so the API call 4xxs and the link falls back to the job summary (always written).
- Auto-updates one marker comment rather than spamming per push, and rewrites it to a 'no changes' note when a later push clears them.

## Why
A PR comment is the only clickable, unmissable surface reachable with the built-in `GITHUB_TOKEN`, and it covers the real target (teams on private / same-repo PRs). Fork PRs keep the summary fallback.

Docs and examples updated to pass `github-token` and grant `pull-requests: write`. Still no oasdiff account or token required, `github.token` is GitHub's built-in token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)