### PR TITLE
fix: install curl in the breaking/changelog images for the PR comment

### DIFF
--- a/breaking/Dockerfile
+++ b/breaking/Dockerfile
@@ -1,5 +1,5 @@
 FROM tufin/oasdiff:v1.18.6
-RUN apk add --no-cache jq
+RUN apk add --no-cache curl jq
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/changelog/Dockerfile
+++ b/changelog/Dockerfile
@@ -1,5 +1,5 @@
 FROM tufin/oasdiff:v1.18.6
-RUN apk add --no-cache jq
+RUN apk add --no-cache curl jq
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
The PR-comment feature (#156) added `curl` calls to the `breaking` and `changelog` entrypoints (to post the review link), but those images only install `jq`, curl was never needed there before. Without curl the API call returns HTTP 000 and the action falls back to the job summary with a notice.

Add `curl` to both Dockerfiles (it also pulls in `ca-certificates`), matching the `pr-comment` image which already installs `curl jq`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)