### PR TITLE
Add a 'learn more' link to the review PR comment

### DIFF
--- a/breaking/entrypoint.sh
+++ b/breaking/entrypoint.sh
@@ -57,7 +57,7 @@ post_review_comment () {
         body="${marker}
 ### 📋 [View the side-by-side API change review](${review_url})
 
-The two specs were encrypted in CI before upload and the decryption key stays in this link, so oasdiff cannot read them. Anyone with the link can open the review; it expires after 7 days."
+The two specs were encrypted in CI before upload and the decryption key stays in this link, so oasdiff cannot read them. Anyone with the link can open the review; it expires after 7 days. [How this works, and how to turn it off →](https://www.oasdiff.com/docs/free-review)"
     elif [ -n "$existing_id" ]; then
         body="${marker}
 ### ✅ No breaking changes in the latest revision."

--- a/changelog/entrypoint.sh
+++ b/changelog/entrypoint.sh
@@ -76,7 +76,7 @@ post_review_comment () {
         body="${marker}
 ### 📋 [View the side-by-side API change review](${review_url})
 
-The two specs were encrypted in CI before upload and the decryption key stays in this link, so oasdiff cannot read them. Anyone with the link can open the review; it expires after 7 days."
+The two specs were encrypted in CI before upload and the decryption key stays in this link, so oasdiff cannot read them. Anyone with the link can open the review; it expires after 7 days. [How this works, and how to turn it off →](https://www.oasdiff.com/docs/free-review)"
     elif [ -n "$existing_id" ]; then
         body="${marker}
 ### ✅ No API changes in the latest revision."


### PR DESCRIPTION
The PR comment posted by the `breaking`/`changelog` actions explains that the specs are encrypted in CI. Add a trailing link so reviewers can read the full mechanism (decryption key lives only in the URL fragment, 7-day expiry) and maintainers can find how to turn it off (`review: false`):

`[How this works, and how to turn it off →](https://www.oasdiff.com/docs/free-review)`

The /docs/free-review page already covers the encryption model, key-in-fragment, expiry, and the `review: false` opt-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)