### PR TITLE
Rework the free-review PR comment copy (lead with use + sharing)

### DIFF
--- a/breaking/entrypoint.sh
+++ b/breaking/entrypoint.sh
@@ -57,7 +57,9 @@ post_review_comment () {
         body="${marker}
 ### 📋 [View the side-by-side API change review](${review_url})
 
-The two specs were encrypted in CI before upload and the decryption key stays in this link, so oasdiff cannot read them. Anyone with the link can open the review; it expires after 7 days. [How this works, and how to turn it off →](https://www.oasdiff.com/docs/free-review)"
+See exactly what changed, in context. Share this link with your team: anyone can open the review, no install and no account needed. It expires in 7 days.
+
+🔒 Your specs stay private. They're encrypted before upload, and only this link can unlock them. [How it works →](https://www.oasdiff.com/docs/free-review)"
     elif [ -n "$existing_id" ]; then
         body="${marker}
 ### ✅ No breaking changes in the latest revision."

--- a/changelog/entrypoint.sh
+++ b/changelog/entrypoint.sh
@@ -76,7 +76,9 @@ post_review_comment () {
         body="${marker}
 ### 📋 [View the side-by-side API change review](${review_url})
 
-The two specs were encrypted in CI before upload and the decryption key stays in this link, so oasdiff cannot read them. Anyone with the link can open the review; it expires after 7 days. [How this works, and how to turn it off →](https://www.oasdiff.com/docs/free-review)"
+See exactly what changed, in context. Share this link with your team: anyone can open the review, no install and no account needed. It expires in 7 days.
+
+🔒 Your specs stay private. They're encrypted before upload, and only this link can unlock them. [How it works →](https://www.oasdiff.com/docs/free-review)"
     elif [ -n "$existing_id" ]; then
         body="${marker}
 ### ✅ No API changes in the latest revision."


### PR DESCRIPTION
Feedback on the comment the free `breaking`/`changelog` actions post: the previous body led with privacy mechanics and missed the most important thing, getting people to **open and share** the review.

Before:
> The two specs were encrypted in CI before upload and the decryption key stays in this link, so oasdiff cannot read them. Anyone with the link can open the review; it expires after 7 days. [How this works, and how to turn it off →]

After:
> See exactly what changed, in context. Share this link with your team: anyone can open the review, no install and no account needed. It expires in 7 days.
>
> 🔒 Your specs stay private. They're encrypted before upload, and only this link can unlock them. [How it works →]

- Leads with use + **team sharing** (was missing).
- Privacy collapsed to one line + a link to /docs/free-review for the full mechanism (and the `review: false` opt-out).
- This detail is first-read-only and ignored afterward, so the comment stays short and use-focused.

Applied to both `breaking` and `changelog`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)