### PR TITLE
docs: point the comment 'How it works' link at the #privacy anchor

### DIFF
--- a/breaking/entrypoint.sh
+++ b/breaking/entrypoint.sh
@@ -59,7 +59,7 @@ post_review_comment () {
 
 See exactly what changed, in context. Share this link with your team: anyone can open the review, no install and no account needed. It expires in 7 days.
 
-🔒 Your specs stay private. They're encrypted before upload, and only this link can unlock them. [How it works →](https://www.oasdiff.com/docs/free-review)"
+🔒 Your specs stay private. They're encrypted before upload, and only this link can unlock them. [How it works →](https://www.oasdiff.com/docs/free-review#privacy)"
     elif [ -n "$existing_id" ]; then
         body="${marker}
 ### ✅ No breaking changes in the latest revision."

--- a/changelog/entrypoint.sh
+++ b/changelog/entrypoint.sh
@@ -78,7 +78,7 @@ post_review_comment () {
 
 See exactly what changed, in context. Share this link with your team: anyone can open the review, no install and no account needed. It expires in 7 days.
 
-🔒 Your specs stay private. They're encrypted before upload, and only this link can unlock them. [How it works →](https://www.oasdiff.com/docs/free-review)"
+🔒 Your specs stay private. They're encrypted before upload, and only this link can unlock them. [How it works →](https://www.oasdiff.com/docs/free-review#privacy)"
     elif [ -n "$existing_id" ]; then
         body="${marker}
 ### ✅ No API changes in the latest revision."


### PR DESCRIPTION
Follow-up to the dedicated privacy section (w3 #345): point the PR comment's 'How it works →' link at `/docs/free-review#privacy` so it lands directly on the explanation instead of the top of the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)