### PR TITLE
bump: verify action base image to oasdiff v1.19.0

### DIFF
--- a/verify/Dockerfile
+++ b/verify/Dockerfile
@@ -1,4 +1,4 @@
-FROM tufin/oasdiff:v1.18.4
+FROM tufin/oasdiff:v1.19.0
 RUN apk add --no-cache curl jq
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
The release bump PR (#161) bumped breaking/changelog/diff/validate/pr-comment to `tufin/oasdiff:v1.19.0` but not `verify` (the release script's loop skipped it; I've since fixed the script). This brings `verify` onto v1.19.0 too, so all six actions share the release base image before the v0.1.0 tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)