### PR TITLE
Nudge users to enable the PR comment when github-token is missing

### DIFF
--- a/breaking/entrypoint.sh
+++ b/breaking/entrypoint.sh
@@ -37,8 +37,17 @@ readonly github_token="${17}"
 #     a PR that never had changes stays comment-free).
 post_review_comment () {
     review_url="$1"
-    [ -z "$github_token" ] && return 0
     pr_number=$(echo "$GITHUB_REF" | sed -n 's|refs/pull/\([0-9]*\)/merge|\1|p')
+    if [ -z "$github_token" ]; then
+        # No token to comment with. If we produced a review link on a PR, nudge
+        # the user to enable the PR comment rather than failing silently (the
+        # link is still in the job summary). This is the default for anyone who
+        # upgraded the action version without adding github-token + permissions.
+        if [ -n "$review_url" ] && [ -n "$pr_number" ]; then
+            echo "::notice::oasdiff put the side-by-side review link in the job summary. To post it as a pull-request comment instead, pass 'github-token: \${{ github.token }}' to the action and grant the job 'permissions: pull-requests: write'. See https://www.oasdiff.com/docs/github-action"
+        fi
+        return 0
+    fi
     [ -z "$pr_number" ] && return 0
     owner="${GITHUB_REPOSITORY%%/*}"
     repo="${GITHUB_REPOSITORY#*/}"

--- a/changelog/entrypoint.sh
+++ b/changelog/entrypoint.sh
@@ -56,8 +56,17 @@ readonly github_token="${17}"
 #     had changes stays comment-free).
 post_review_comment () {
     review_url="$1"
-    [ -z "$github_token" ] && return 0
     pr_number=$(echo "$GITHUB_REF" | sed -n 's|refs/pull/\([0-9]*\)/merge|\1|p')
+    if [ -z "$github_token" ]; then
+        # No token to comment with. If we produced a review link on a PR, nudge
+        # the user to enable the PR comment rather than failing silently (the
+        # link is still in the job summary). This is the default for anyone who
+        # upgraded the action version without adding github-token + permissions.
+        if [ -n "$review_url" ] && [ -n "$pr_number" ]; then
+            echo "::notice::oasdiff put the side-by-side review link in the job summary. To post it as a pull-request comment instead, pass 'github-token: \${{ github.token }}' to the action and grant the job 'permissions: pull-requests: write'. See https://www.oasdiff.com/docs/github-action"
+        fi
+        return 0
+    fi
     [ -z "$pr_number" ] && return 0
     owner="${GITHUB_REPOSITORY%%/*}"
     repo="${GITHUB_REPOSITORY#*/}"


### PR DESCRIPTION
**P0 launch-hardening (#1).** After upgrading to v0.1.0 by bumping only the version (not adding `github-token` + `permissions: pull-requests: write`), the free `breaking`/`changelog` action posted the review link to the **job summary only, silently** — the default for every upgrader, landing on the low-traffic surface the whole encrypted-review effort was meant to escape.

Now, when a review link is produced **on a pull request** but no `github-token` is set, the action emits a `::notice::` explaining how to get the review as a PR comment (with a docs link). It fires only when there's a review link + PR context, so no-changes runs and non-PR events stay quiet, and fork PRs (which have a read-only token present) keep the existing 403-fallback notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)