### PR TITLE
fix(review): read the --open review URL from stderr (oasdiff >= v1.19.1)

### DIFF
--- a/breaking/entrypoint.sh
+++ b/breaking/entrypoint.sh
@@ -230,14 +230,15 @@ if [ "$changes_exit" -eq 1 ]; then
             # "couldn't upload" warning below.
             echo "::notice::oasdiff: the side-by-side review isn't available in composed mode (-c). The breaking-change report above is unaffected."
         else
-            # --open prints the review URL on stdout; in CI the browser-open
-            # step soft-fails. We grep the /review/e/ URL out by its stable path
-            # shape (not by surrounding prose). Tolerate a non-zero exit / no
-            # match so `set -e` doesn't abort the run. --template= overrides a
-            # 'template' set in .oasdiff.yaml, which would otherwise error this
-            # render (templates are rejected for the default text format) and
-            # yield no URL.
-            free_review_url=$(oasdiff breaking "$base" "$revision" $flags --open --template= 2>/dev/null \
+            # --open prints the review URL to stderr (oasdiff >= v1.19.1 moved it
+            # off stdout so it can't corrupt piped --format output); in CI the
+            # browser-open step soft-fails. Merge stderr into the pipe (2>&1) and
+            # grep the /review/e/ URL out by its stable path shape (not by
+            # surrounding prose). Tolerate a non-zero exit / no match so `set -e`
+            # doesn't abort the run. --template= overrides a 'template' set in
+            # .oasdiff.yaml, which would otherwise error this render (templates
+            # are rejected for the default text format) and yield no URL.
+            free_review_url=$(oasdiff breaking "$base" "$revision" $flags --open --template= 2>&1 \
                 | grep -oE 'https://[^[:space:]]+/review/e/[^[:space:]]+' | head -n 1) || true
             if [ -n "$free_review_url" ]; then
                 echo "### 📋 [View these breaking changes in a side-by-side review](${free_review_url})" >> "$GITHUB_STEP_SUMMARY"

--- a/changelog/entrypoint.sh
+++ b/changelog/entrypoint.sh
@@ -227,14 +227,15 @@ if [ "$changes_exit" -eq 1 ]; then
             # "couldn't upload" warning below.
             echo "::notice::oasdiff: the side-by-side review isn't available in composed mode (-c). The changelog above is unaffected."
         else
-            # --open prints the review URL on stdout; in CI the browser-open
-            # step soft-fails. We grep the /review/e/ URL out by its stable path
-            # shape (not by surrounding prose). Tolerate a non-zero exit / no
-            # match so `set -e` doesn't abort the run. --template= overrides a
-            # 'template' set in .oasdiff.yaml, which would otherwise error this
-            # render (templates are rejected for the default text format) and
-            # yield no URL.
-            free_review_url=$(oasdiff changelog "$base" "$revision" $flags --open --template= 2>/dev/null \
+            # --open prints the review URL to stderr (oasdiff >= v1.19.1 moved it
+            # off stdout so it can't corrupt piped --format output); in CI the
+            # browser-open step soft-fails. Merge stderr into the pipe (2>&1) and
+            # grep the /review/e/ URL out by its stable path shape (not by
+            # surrounding prose). Tolerate a non-zero exit / no match so `set -e`
+            # doesn't abort the run. --template= overrides a 'template' set in
+            # .oasdiff.yaml, which would otherwise error this render (templates
+            # are rejected for the default text format) and yield no URL.
+            free_review_url=$(oasdiff changelog "$base" "$revision" $flags --open --template= 2>&1 \
                 | grep -oE 'https://[^[:space:]]+/review/e/[^[:space:]]+' | head -n 1) || true
             if [ -n "$free_review_url" ]; then
                 echo "### 📋 [View these API changes in a side-by-side review](${free_review_url})" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## What

oasdiff **v1.19.1** (oasdiff/oasdiff#1011) moved the `Opening <url>` line from **stdout to stderr** so `--open` can't corrupt piped `--format json/yaml` output. But the action's `--open` run extracts the review URL by grepping **stdout** with `2>/dev/null`:

```sh
free_review_url=$(oasdiff breaking ... --open --template= 2>/dev/null | grep .../review/e/...)
```

Against v1.19.1 that finds nothing → the action emits the misleading "couldn't upload, re-run the job" warning and posts **no review comment at all**, silently breaking the entire free-review link.

## Fix

Merge stderr into the pipe (`2>&1`) so the URL is captured regardless of which stream oasdiff prints it on. Works with both old (stdout, ≤ v1.19.0) and new (stderr, ≥ v1.19.1) oasdiff.

## How it was caught

The w3 encrypted-review e2e, run against `tufin/oasdiff:latest` (main HEAD, with #1011) via a `test/oasdiff-latest-image` action branch: the workflow failed the gate as expected but no `/review/e` comment appeared; the run log showed `oasdiff: couldn't upload the side-by-side review`. **This must merge before action v0.1.1 is cut on oasdiff v1.19.1.**

## Test

`sh -n` clean on both entrypoints; re-validated by re-running the encrypted-review e2e with this fix applied (green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)