### PR TITLE
Default github-token to github.token so the review comment posts without setup

### DIFF
--- a/breaking/action.yml
+++ b/breaking/action.yml
@@ -61,9 +61,9 @@ inputs:
     required: false
     default: 'true'
   github-token:
-    description: 'GitHub token used to post the review link as a pull-request comment, so reviewers see it on the PR instead of only in the job summary. Pass the built-in github.token and grant the job permissions: pull-requests: write. Optional; when omitted the link is written only to the job summary. On fork pull requests the token is read-only, so commenting is skipped and the link falls back to the job summary.'
+    description: 'GitHub token used to post the review link as a pull-request comment, so reviewers see it on the PR instead of only in the job summary. Defaults to the built-in github.token, so the comment is posted automatically when the job grants permissions: pull-requests: write. Set to an empty string to disable the comment (the link then appears only in the job summary). On fork pull requests the token is read-only, so commenting is skipped and the link falls back to the job summary.'
     required: false
-    default: ''
+    default: ${{ github.token }}
 outputs:
   breaking:
     description: 'Output summary of API breaking changes, encompassing both warnings and errors'

--- a/breaking/entrypoint.sh
+++ b/breaking/entrypoint.sh
@@ -70,7 +70,7 @@ The link expires in 7 days.
 
 🔒 Your API specs are encrypted in CI before they're uploaded. The decryption key stays in this link's URL fragment (after the #), which browsers never send to a server, so oasdiff cannot read your specs. [How it works →](https://www.oasdiff.com/docs/free-review#privacy)
 
-<sub>Posted automatically by the oasdiff GitHub Action. To stop posting this comment, set \`review: false\` on the action.</sub>"
+<sub>Posted automatically by the [oasdiff GitHub Action](https://www.oasdiff.com/docs/free-review#github-action). To turn this off (no spec upload, no comment), set \`review: false\` on the action.</sub>"
     elif [ -n "$existing_id" ]; then
         body="${marker}
 ### ✅ No breaking changes in the latest revision."

--- a/breaking/entrypoint.sh
+++ b/breaking/entrypoint.sh
@@ -66,7 +66,7 @@ post_review_comment () {
         body="${marker}
 ### 📋 [View the side-by-side API change review](${review_url})
 
-See exactly what changed, in context. Share this link with your team: anyone with the link can open the review, no install or account needed. It expires in 7 days.
+The link expires in 7 days.
 
 🔒 Your API specs are encrypted in CI before they're uploaded. The decryption key stays in this link's URL fragment (after the #), which browsers never send to a server, so oasdiff cannot read your specs. [How it works →](https://www.oasdiff.com/docs/free-review#privacy)
 

--- a/breaking/entrypoint.sh
+++ b/breaking/entrypoint.sh
@@ -66,9 +66,11 @@ post_review_comment () {
         body="${marker}
 ### 📋 [View the side-by-side API change review](${review_url})
 
-See exactly what changed, in context. Share this link with your team: anyone can open the review, no install and no account needed. It expires in 7 days.
+See exactly what changed, in context. Share this link with your team: anyone with the link can open the review, no install or account needed. It expires in 7 days.
 
-🔒 Your specs stay private. They're encrypted before upload, and only this link can unlock them. [How it works →](https://www.oasdiff.com/docs/free-review#privacy)"
+🔒 Your API specs are encrypted in CI before they're uploaded. The decryption key stays in this link's URL fragment (after the #), which browsers never send to a server, so oasdiff cannot read your specs. [How it works →](https://www.oasdiff.com/docs/free-review#privacy)
+
+<sub>Posted automatically by the oasdiff GitHub Action. To stop posting this comment, set \`review: false\` on the action.</sub>"
     elif [ -n "$existing_id" ]; then
         body="${marker}
 ### ✅ No breaking changes in the latest revision."

--- a/changelog/action.yml
+++ b/changelog/action.yml
@@ -64,9 +64,9 @@ inputs:
     required: false
     default: 'true'
   github-token:
-    description: 'GitHub token used to post the review link as a pull-request comment, so reviewers see it on the PR instead of only in the job summary. Pass the built-in github.token and grant the job permissions: pull-requests: write. Optional; when omitted the link is written only to the job summary. On fork pull requests the token is read-only, so commenting is skipped and the link falls back to the job summary.'
+    description: 'GitHub token used to post the review link as a pull-request comment, so reviewers see it on the PR instead of only in the job summary. Defaults to the built-in github.token, so the comment is posted automatically when the job grants permissions: pull-requests: write. Set to an empty string to disable the comment (the link then appears only in the job summary). On fork pull requests the token is read-only, so commenting is skipped and the link falls back to the job summary.'
     required: false
-    default: ''
+    default: ${{ github.token }}
 outputs:
   changelog:
     description: 'Output summary of API changelog'

--- a/changelog/entrypoint.sh
+++ b/changelog/entrypoint.sh
@@ -89,7 +89,7 @@ The link expires in 7 days.
 
 🔒 Your API specs are encrypted in CI before they're uploaded. The decryption key stays in this link's URL fragment (after the #), which browsers never send to a server, so oasdiff cannot read your specs. [How it works →](https://www.oasdiff.com/docs/free-review#privacy)
 
-<sub>Posted automatically by the oasdiff GitHub Action. To stop posting this comment, set \`review: false\` on the action.</sub>"
+<sub>Posted automatically by the [oasdiff GitHub Action](https://www.oasdiff.com/docs/free-review#github-action). To turn this off (no spec upload, no comment), set \`review: false\` on the action.</sub>"
     elif [ -n "$existing_id" ]; then
         body="${marker}
 ### ✅ No API changes in the latest revision."

--- a/changelog/entrypoint.sh
+++ b/changelog/entrypoint.sh
@@ -85,9 +85,11 @@ post_review_comment () {
         body="${marker}
 ### 📋 [View the side-by-side API change review](${review_url})
 
-See exactly what changed, in context. Share this link with your team: anyone can open the review, no install and no account needed. It expires in 7 days.
+See exactly what changed, in context. Share this link with your team: anyone with the link can open the review, no install or account needed. It expires in 7 days.
 
-🔒 Your specs stay private. They're encrypted before upload, and only this link can unlock them. [How it works →](https://www.oasdiff.com/docs/free-review#privacy)"
+🔒 Your API specs are encrypted in CI before they're uploaded. The decryption key stays in this link's URL fragment (after the #), which browsers never send to a server, so oasdiff cannot read your specs. [How it works →](https://www.oasdiff.com/docs/free-review#privacy)
+
+<sub>Posted automatically by the oasdiff GitHub Action. To stop posting this comment, set \`review: false\` on the action.</sub>"
     elif [ -n "$existing_id" ]; then
         body="${marker}
 ### ✅ No API changes in the latest revision."

--- a/changelog/entrypoint.sh
+++ b/changelog/entrypoint.sh
@@ -85,7 +85,7 @@ post_review_comment () {
         body="${marker}
 ### 📋 [View the side-by-side API change review](${review_url})
 
-See exactly what changed, in context. Share this link with your team: anyone with the link can open the review, no install or account needed. It expires in 7 days.
+The link expires in 7 days.
 
 🔒 Your API specs are encrypted in CI before they're uploaded. The decryption key stays in this link's URL fragment (after the #), which browsers never send to a server, so oasdiff cannot read your specs. [How it works →](https://www.oasdiff.com/docs/free-review#privacy)
 


### PR DESCRIPTION
## Why

Most repos picked up the encrypted free review by tracking a moving action ref, not by a proactive upgrade, so they never added `github-token` + `permissions`. The review link then goes only to the **job summary**, which almost nobody opens. Production day 2: **~476 reviews created, 3 opened** (~0.6%). The feature is on, but invisible.

## Change

Default `github-token` to `${{ github.token }}` in `breaking/action.yml` and `changelog/action.yml`. The PR comment now posts automatically on any repo whose job `GITHUB_TOKEN` already has write access, **with no workflow edit**. Repos whose org forces a read-only default token still fall back to the job summary (the `permissions: pull-requests: write` line genuinely needs a workflow edit); fork PRs are unchanged (read-only token).

Verified end-to-end in CI: a workflow that does **not** pass `github-token` posted the comment via the resolved default (`github-actions[bot]`). Confirmed the expression default resolves through the Docker `args` path (the `with:` block logged `github-token: ***`, a masked non-empty value, despite nothing being passed).

## Comment copy

Since the comment is now posted by default, it's the first-touch notice for many maintainers, so it's been made more transparent:

- "anyone **with the link** can open" (states the capability-by-URL model) instead of "anyone can open";
- precise privacy wording: "encrypted in CI before upload; the decryption key stays in this link's URL fragment, which browsers never send to a server, so oasdiff cannot read your specs" (instead of the absolute "specs stay private");
- an explicit opt-out footer: "Posted automatically by the oasdiff GitHub Action. To stop posting this comment, set `review: false`."

🤖 Generated with [Claude Code](https://claude.com/claude-code)