### PR TITLE
actions: drop "zero-knowledge" jargon from the review input docs

### DIFF
--- a/breaking/action.yml
+++ b/breaking/action.yml
@@ -57,7 +57,7 @@ inputs:
     required: false
     default: 'false'
   review:
-    description: 'Upload the comparison to oasdiff.com (encrypted, zero-knowledge) and link straight to a side-by-side review of these changes. The specs are encrypted client-side and the key stays in the URL fragment, so the server cannot read them. Set to false to skip the upload entirely, so no spec leaves CI; the change detection and inline annotations are unaffected.'
+    description: 'Upload the comparison to oasdiff.com and link straight to a side-by-side review of these changes. The specs are encrypted client-side and the key stays in the URL fragment, so the server cannot read them. Set to false to skip the upload entirely, so no spec leaves CI; the change detection and inline annotations are unaffected.'
     required: false
     default: 'true'
   github-token:

--- a/changelog/action.yml
+++ b/changelog/action.yml
@@ -60,7 +60,7 @@ inputs:
     required: false
     default: 'false'
   review:
-    description: 'Upload the comparison to oasdiff.com (encrypted, zero-knowledge) and link straight to a side-by-side review of these changes. The specs are encrypted client-side and the key stays in the URL fragment, so the server cannot read them. Set to false to skip the upload entirely, so no spec leaves CI; the change detection and inline annotations are unaffected.'
+    description: 'Upload the comparison to oasdiff.com and link straight to a side-by-side review of these changes. The specs are encrypted client-side and the key stays in the URL fragment, so the server cannot read them. Set to false to skip the upload entirely, so no spec leaves CI; the change detection and inline annotations are unaffected.'
     required: false
     default: 'true'
   github-token:


### PR DESCRIPTION
Consistency with the user-facing copy on oasdiff.com (pricing, /setup, release notes): the `review` input description for the `breaking` and `changelog` actions drops the "(encrypted, zero-knowledge)" parenthetical. The sentence right after already says it in user terms: "The specs are encrypted client-side and the key stays in the URL fragment, so the server cannot read them."