### PR TITLE
README and PR comment: clearer, standard wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![validate](https://github.com/oasdiff/oasdiff-action/actions/workflows/test-validate.yaml/badge.svg)](https://github.com/oasdiff/oasdiff-action/actions/workflows/test-validate.yaml)
 [![verify](https://github.com/oasdiff/oasdiff-action/actions/workflows/test-verify.yaml/badge.svg)](https://github.com/oasdiff/oasdiff-action/actions/workflows/test-verify.yaml)
 
-GitHub Actions for comparing OpenAPI specs and detecting breaking changes, based on [oasdiff](https://github.com/oasdiff/oasdiff).
+GitHub Actions that turn every pull request into an API change review: detect breaking changes in CI, post a side-by-side review, and (with Pro) approve or reject each change with a merge gate. Code review, for your API contract. Based on [oasdiff](https://github.com/oasdiff/oasdiff).
 
 ## Contents
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![validate](https://github.com/oasdiff/oasdiff-action/actions/workflows/test-validate.yaml/badge.svg)](https://github.com/oasdiff/oasdiff-action/actions/workflows/test-validate.yaml)
 [![verify](https://github.com/oasdiff/oasdiff-action/actions/workflows/test-verify.yaml/badge.svg)](https://github.com/oasdiff/oasdiff-action/actions/workflows/test-verify.yaml)
 
-GitHub Actions that turn every pull request into an API change review: detect breaking changes in CI, post a side-by-side review, and (with Pro) approve or reject each change with a merge gate. Code review, for your API contract. Based on [oasdiff](https://github.com/oasdiff/oasdiff).
+GitHub Actions that check your OpenAPI specs for breaking changes on every pull request. They post a side-by-side review of the changes as a PR comment and, with Pro, let your team approve or reject each change with a commit-status check that gates the merge. Based on [oasdiff](https://github.com/oasdiff/oasdiff).
 
 ## Contents
 

--- a/changelog/entrypoint.sh
+++ b/changelog/entrypoint.sh
@@ -178,7 +178,7 @@ pro_comment () {
     review_url="$1"
     gate="$2"
     if [ -z "$github_token" ]; then
-        echo "::notice::oasdiff: review uploaded; add 'github-token: \${{ github.token }}' and grant 'permissions: pull-requests: write, statuses: write' to post the review comment and set the merge gate. The link is in the job summary."
+        echo "::notice::oasdiff: review uploaded; add 'github-token: \${{ github.token }}' and grant 'permissions: pull-requests: write, statuses: write' to post the review comment and set the \`oasdiff\` status check. The link is in the job summary."
         return 0
     fi
     api="${GITHUB_API_URL:-https://api.github.com}"
@@ -186,7 +186,7 @@ pro_comment () {
     case "$gate" in
         approved) status_line="✅ All changes approved." ;;
         rejected) status_line="❌ Changes requested." ;;
-        *)        status_line="⏳ Review required: approve every change to clear the \`oasdiff\` merge gate." ;;
+        *)        status_line="⏳ Review required: approve every change to make the \`oasdiff\` status check pass." ;;
     esac
 
     existing_id=$(curl -s \
@@ -202,7 +202,7 @@ ${status_line}
 
 🔒 The comparison is encrypted in CI before it's uploaded. The decryption key stays in this link's fragment (after the #), which browsers never send to a server, so oasdiff cannot read your specs.
 
-<sub>Posted automatically by the [oasdiff GitHub Action](https://www.oasdiff.com/docs/setup). The \`oasdiff\` status check gates merge until every change is approved.</sub>"
+<sub>Posted automatically by the [oasdiff GitHub Action](https://www.oasdiff.com/docs/setup). The \`oasdiff\` status check passes once every change is approved; make it a required check to block merging.</sub>"
 
     payload=$(jq -n --arg body "$body" '{body: $body}')
     if [ -n "$existing_id" ]; then


### PR DESCRIPTION
Clarifies the wording on the action's README and on the PR comment it posts. Copy only, no behavior change.

- **README tagline** now describes what the actions do: check your OpenAPI specs for breaking changes on every pull request, post a side-by-side review as a PR comment, and (with Pro) approve or reject each change with a commit-status check that can block the merge.
- **PR comment + CI notices** use standard GitHub terms ("status check", "check passes", "required check to block merging") for clarity.