### PR TITLE
ci: add Dependabot for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds a `github-actions` Dependabot ecosystem (weekly, grouped into one PR) so action versions are bumped automatically. The repo had no Dependabot config, so actions like `actions/checkout` had drifted behind the latest major.