### PR TITLE
docs: bump example actions/checkout to v7

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ jobs:
   breaking-changes:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: git fetch --depth=1 origin ${{ github.base_ref }}
       - uses: oasdiff/oasdiff-action/breaking@v0
         with:
@@ -64,7 +64,7 @@ The examples above pin the action at `@v0`, the moving major-version tag. It alw
 `@v0` only advances on stable releases, never on prereleases. If you prefer to control upgrades yourself, pin an exact release instead and bump it when you choose:
 
 ```yaml
-- uses: oasdiff/oasdiff-action/breaking@v0.1.1
+- uses: oasdiff/oasdiff-action/breaking@v0.1.3
 ```
 
 `@main` runs the unreleased tip and is meant for trying changes early, not for production.
@@ -91,7 +91,7 @@ jobs:
   breaking-changes:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: git fetch --depth=1 origin ${{ github.base_ref }}
       - uses: oasdiff/oasdiff-action/breaking@v0
         with:
@@ -137,7 +137,7 @@ jobs:
   changelog:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: git fetch --depth=1 origin ${{ github.base_ref }}
       - uses: oasdiff/oasdiff-action/changelog@v0
         with:
@@ -179,7 +179,7 @@ jobs:
   diff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: git fetch --depth=1 origin ${{ github.base_ref }}
       - uses: oasdiff/oasdiff-action/diff@v0
         with:
@@ -214,7 +214,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: oasdiff/oasdiff-action/validate@v0
         with:
           spec: 'openapi.yaml'
@@ -282,7 +282,7 @@ The `base` and `revision` inputs accept:
 When using git refs, you need to check out the repo and fetch the base branch:
 
 ```yaml
-- uses: actions/checkout@v6
+- uses: actions/checkout@v7
 - run: git fetch --depth=1 origin ${{ github.base_ref }}
 ```
 
@@ -305,7 +305,7 @@ jobs:
   pr-comment:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: git fetch --depth=1 origin ${{ github.base_ref }}
       - uses: oasdiff/oasdiff-action/pr-comment@v0
         with:
@@ -353,7 +353,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: git fetch --depth=1 origin ${{ github.base_ref }}
       - uses: oasdiff/oasdiff-action/pr-comment@v0
         with:
@@ -364,7 +364,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - run: git fetch --depth=1 origin ${{ github.event.repository.default_branch }}
       - uses: oasdiff/oasdiff-action/verify@v0
         with:

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This compares your spec on the PR branch against the base branch and fails the w
 
 ## Versioning
 
-The examples above pin the action at `@v0`, the moving major-version tag. It always points at the latest `v0.x.y` release, so you get every later patch and minor (including review and PR-comment improvements) automatically, with no workflow change:
+The examples here pin the action at `@v0`, the moving major-version tag. It always points at the latest `v0.x.y` release, so you get every later patch and minor (including review and PR-comment improvements) automatically, with no workflow change:
 
 ```yaml
 - uses: oasdiff/oasdiff-action/breaking@v0

--- a/README.md
+++ b/README.md
@@ -61,13 +61,7 @@ The examples above pin the action at `@v0`, the moving major-version tag. It alw
 - uses: oasdiff/oasdiff-action/breaking@v0
 ```
 
-`@v0` only advances on stable releases, never on prereleases. If you prefer to control upgrades yourself, pin an exact release instead and bump it when you choose:
-
-```yaml
-- uses: oasdiff/oasdiff-action/breaking@v0.1.3
-```
-
-`@main` runs the unreleased tip and is meant for trying changes early, not for production.
+`@v0` only advances on stable releases, never on prereleases. If you prefer to control upgrades yourself, pin to a specific release tag from the [Releases page](https://github.com/oasdiff/oasdiff-action/releases) and bump it when you choose. `@main` runs the unreleased tip and is meant for trying changes early, not for production.
 
 ---
 


### PR DESCRIPTION
The copyable workflow examples used `actions/checkout@v6` (latest is **v7**), so users pasting them got a one-major-old checkout. Bumped all 9 to v7. Also updated the one illustrative exact-pin example from `@v0.1.1` to `@v0.1.3` (the current release); the recommended `@v0` moving tag is unchanged.