### PR TITLE
ci: stop double-running test workflows on PR branches

### DIFF
--- a/.github/workflows/test-breaking.yaml
+++ b/.github/workflows/test-breaking.yaml
@@ -1,7 +1,8 @@
 name: breaking
 on:
-  pull_request:
   push:
+    branches: [main]
+  pull_request:
 jobs:
   oasdiff_breaking:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-changelog.yaml
+++ b/.github/workflows/test-changelog.yaml
@@ -1,7 +1,8 @@
 name: changelog
 on:
-  pull_request:
   push:
+    branches: [main]
+  pull_request:
 jobs:
   oasdiff_changelog:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-diff.yaml
+++ b/.github/workflows/test-diff.yaml
@@ -1,7 +1,8 @@
 name: diff
 on:
-  pull_request:
   push:
+    branches: [main]
+  pull_request:
 jobs:
   oasdiff_diff:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-error-annotation.yaml
+++ b/.github/workflows/test-error-annotation.yaml
@@ -1,7 +1,8 @@
 name: error-annotation
 on:
-  pull_request:
   push:
+    branches: [main]
+  pull_request:
 jobs:
   entrypoint_error_annotation:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-pr-comment.yaml
+++ b/.github/workflows/test-pr-comment.yaml
@@ -1,7 +1,8 @@
 name: pr-comment
 on:
-  pull_request:
   push:
+    branches: [main]
+  pull_request:
 jobs:
   pr_comment_tolerates_oasdiff_fail_on:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-validate.yaml
+++ b/.github/workflows/test-validate.yaml
@@ -1,7 +1,8 @@
 name: validate
 on:
-  pull_request:
   push:
+    branches: [main]
+  pull_request:
 jobs:
   oasdiff_validate_valid:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-verify.yaml
+++ b/.github/workflows/test-verify.yaml
@@ -1,6 +1,7 @@
 name: test verify
 on:
   push:
+    branches: [main]
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Problem

All seven `test-*` workflows triggered on both `push` and `pull_request` with no branch filter:

```yaml
on:
  pull_request:
  push:
```

So every push to a PR branch fires both events, running each workflow twice.

## Fix

Restrict `push` to `main` (same change just applied to oasdiff):

```yaml
on:
  push:
    branches: [main]
  pull_request:
```

- PR branch pushes now trigger only `pull_request` (one run).
- A merge to `main` triggers only `push` (one run).
- `pull_request` stays unfiltered so PRs against any base branch still run.

No coverage lost: every change runs on its PR and again on `main` after merge. Roughly halves Actions usage across these seven workflows.