### PR TITLE
ci: cancel superseded PR runs (concurrency groups)

### DIFF
--- a/.github/workflows/test-breaking.yaml
+++ b/.github/workflows/test-breaking.yaml
@@ -3,6 +3,10 @@ on:
   push:
     branches: [main]
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   oasdiff_breaking:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-changelog.yaml
+++ b/.github/workflows/test-changelog.yaml
@@ -3,6 +3,10 @@ on:
   push:
     branches: [main]
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   oasdiff_changelog:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-diff.yaml
+++ b/.github/workflows/test-diff.yaml
@@ -3,6 +3,10 @@ on:
   push:
     branches: [main]
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   oasdiff_diff:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-error-annotation.yaml
+++ b/.github/workflows/test-error-annotation.yaml
@@ -3,6 +3,10 @@ on:
   push:
     branches: [main]
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   entrypoint_error_annotation:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-pr-comment.yaml
+++ b/.github/workflows/test-pr-comment.yaml
@@ -3,6 +3,10 @@ on:
   push:
     branches: [main]
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   pr_comment_tolerates_oasdiff_fail_on:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-validate.yaml
+++ b/.github/workflows/test-validate.yaml
@@ -3,6 +3,10 @@ on:
   push:
     branches: [main]
   pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   oasdiff_validate_valid:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-verify.yaml
+++ b/.github/workflows/test-verify.yaml
@@ -4,6 +4,10 @@ on:
     branches: [main]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   verify_all_green:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds a concurrency group to all seven `test-*` workflows so a new push to a PR branch cancels the in-progress run for that ref instead of running both. Scoped to `pull_request` via `cancel-in-progress: ${{ github.event_name == 'pull_request' }}`, so `main` post-merge runs always finish. Frees runner slots and speeds feedback; no change to what is tested. (Public repo, so this is hygiene/latency rather than billed minutes.)