### PR TITLE
docs: state what changelog, breaking, and diff each cover

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The following actions run the oasdiff CLI directly in your GitHub runner — no 
 
 ### Check for breaking changes
 
-Detects breaking changes and writes inline `::error::` annotations on the pull request's Files changed tab. Fails the workflow when changes at or above the `fail-on` severity are found. When changes are found it also uploads the comparison and links to a full side-by-side review (the `review` input, on by default); the two specs are encrypted in CI before upload, so the server cannot read them. The link is posted as a pull-request comment when you pass `github-token` (and grant `pull-requests: write`); otherwise, and on fork PRs where the token is read-only, it falls back to the job summary.
+Detects changes that break existing API clients and writes inline `::error::` annotations on the pull request's Files changed tab. Fails the workflow when changes at or above the `fail-on` severity are found. When changes are found it also uploads the comparison and links to a full side-by-side review (the `review` input, on by default); the two specs are encrypted in CI before upload, so the server cannot read them. The link is posted as a pull-request comment when you pass `github-token` (and grant `pull-requests: write`); otherwise, and on fork PRs where the token is read-only, it falls back to the job summary.
 
 ```yaml
 name: oasdiff
@@ -116,7 +116,7 @@ jobs:
 
 ### Generate a changelog
 
-Outputs all changes (breaking and non-breaking) between two specs. When changes are found it also uploads the comparison and links to a full side-by-side review (the `review` input, on by default); the two specs are encrypted in CI before upload, so the server cannot read them. The link is posted as a pull-request comment when you pass `github-token` (and grant `pull-requests: write`); otherwise, and on fork PRs where the token is read-only, it falls back to the job summary.
+Outputs the changes that can affect API consumers (breaking and non-breaking) between two specs. Documentation-only edits, such as descriptions and examples, are not included; use the diff action to see every difference in the API definition. When changes are found it also uploads the comparison and links to a full side-by-side review (the `review` input, on by default); the two specs are encrypted in CI before upload, so the server cannot read them. The link is posted as a pull-request comment when you pass `github-token` (and grant `pull-requests: write`); otherwise, and on fork PRs where the token is read-only, it falls back to the job summary.
 
 ```yaml
 name: oasdiff
@@ -161,7 +161,7 @@ jobs:
 
 ### Generate a diff report
 
-Outputs the raw structural diff between two specs.
+Outputs the full diff of the API definition between two specs, including documentation-only edits.
 
 ```yaml
 name: oasdiff


### PR DESCRIPTION
The changelog action was described as outputting "all changes (breaking and non-breaking)". That overstates it: documentation-only edits, such as descriptions and examples, are not reported by any check, so a reader cannot tell when they need the diff action instead.

This names the boundary instead, consistently across the three actions:

- breaking: detects the changes that break existing API clients
- changelog: outputs the changes that can affect API consumers, breaking and non-breaking (documentation-only edits are not included; the diff action shows those)
- diff: outputs the full diff of the API definition, including documentation-only edits

Matches the same wording change in oasdiff/oasdiff#1081.

🤖 Generated with [Claude Code](https://claude.com/claude-code)