### PR TITLE
docs: link 'diff action' to its section

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ jobs:
 
 ### Generate a changelog
 
-Outputs the changes that can affect API consumers (breaking and non-breaking) between two specs. Documentation-only edits, such as descriptions and examples, are not included; use the diff action to see every difference in the API definition. When changes are found it also uploads the comparison and links to a full side-by-side review (the `review` input, on by default); the two specs are encrypted in CI before upload, so the server cannot read them. The link is posted as a pull-request comment when you pass `github-token` (and grant `pull-requests: write`); otherwise, and on fork PRs where the token is read-only, it falls back to the job summary.
+Outputs the changes that can affect API consumers (breaking and non-breaking) between two specs. Documentation-only edits, such as descriptions and examples, are not included; use the [diff action](#generate-a-diff-report) to see every difference in the API definition. When changes are found it also uploads the comparison and links to a full side-by-side review (the `review` input, on by default); the two specs are encrypted in CI before upload, so the server cannot read them. The link is posted as a pull-request comment when you pass `github-token` (and grant `pull-requests: write`); otherwise, and on fork PRs where the token is read-only, it falls back to the job summary.
 
 ```yaml
 name: oasdiff


### PR DESCRIPTION
Follow-up to #184: the changelog section's "use the diff action" now links to the Generate a diff report section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)