### PR TITLE
bump: oasdiff v1.26.1

### DIFF
--- a/breaking/Dockerfile
+++ b/breaking/Dockerfile
@@ -1,4 +1,4 @@
-FROM tufin/oasdiff:v1.26.0
+FROM tufin/oasdiff:v1.26.1
 RUN apk add --no-cache curl jq
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh

--- a/changelog/Dockerfile
+++ b/changelog/Dockerfile
@@ -1,4 +1,4 @@
-FROM tufin/oasdiff:v1.26.0
+FROM tufin/oasdiff:v1.26.1
 RUN apk add --no-cache curl jq
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh

--- a/diff/Dockerfile
+++ b/diff/Dockerfile
@@ -1,4 +1,4 @@
-FROM tufin/oasdiff:v1.26.0
+FROM tufin/oasdiff:v1.26.1
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/pr-comment/Dockerfile
+++ b/pr-comment/Dockerfile
@@ -1,4 +1,4 @@
-FROM tufin/oasdiff:v1.26.0
+FROM tufin/oasdiff:v1.26.1
 RUN apk add --no-cache curl jq
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh

--- a/validate/Dockerfile
+++ b/validate/Dockerfile
@@ -1,4 +1,4 @@
-FROM tufin/oasdiff:v1.26.0
+FROM tufin/oasdiff:v1.26.1
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/verify/Dockerfile
+++ b/verify/Dockerfile
@@ -1,4 +1,4 @@
-FROM tufin/oasdiff:v1.26.0
+FROM tufin/oasdiff:v1.26.1
 RUN apk add --no-cache curl jq
 ENV PLATFORM github-action
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
Bumps the base image on all six actions (breaking, changelog, diff, pr-comment, validate, verify) from `tufin/oasdiff:v1.26.0` to `tufin/oasdiff:v1.26.1`.

v1.26.1 fixes GHSA-m3wq-w7x2-4q6m: git revisions were passed to git as operands, so a revision beginning with `-` was parsed as an option rather than a revision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)