### PR TITLE
Stop pretending include-checks works, and point it at .oasdiff.yaml

### DIFF
--- a/.github/workflows/test-breaking.yaml
+++ b/.github/workflows/test-breaking.yaml
@@ -277,3 +277,67 @@ jobs:
             echo "Expected 'No breaking changes' (err-ignore from .oasdiff.yaml should suppress findings) but got '$output'" >&2
             exit 1
           fi
+
+  oasdiff_breaking_yaml_config_severity_levels:
+    runs-on: ubuntu-latest
+    name: Test breaking action picks up severity-levels from .oasdiff.yaml
+    steps:
+      - name: checkout
+        uses: actions/checkout@v7
+      # specs/severity-levels.txt downgrades api-removed-without-deprecation to
+      # info, so the one breaking change these specs produce stops being an
+      # error and fail-on: ERR no longer fails the step.
+      - name: Drop .oasdiff.yaml at repo root
+        run: |
+          cat > .oasdiff.yaml <<EOF
+          severity-levels: specs/severity-levels.txt
+          fail-on: ERR
+          EOF
+      - name: Running breaking action
+        id: test_yaml_severity_levels
+        uses: ./breaking
+        with:
+          base: 'specs/base.yaml'
+          revision: 'specs/revision-breaking.yaml'
+      - name: Assert the finding was downgraded by .oasdiff.yaml
+        run: |
+          delimiter=$(cat /proc/sys/kernel/random/uuid | tr -d '-')
+          output=$(cat <<-$delimiter
+          ${{ steps.test_yaml_severity_levels.outputs.breaking }}
+          $delimiter
+          )
+          if [ "$output" != "No breaking changes" ]; then
+            echo "Expected 'No breaking changes' (severity-levels from .oasdiff.yaml should downgrade the finding to info) but got '$output'" >&2
+            exit 1
+          fi
+
+  oasdiff_breaking_include_checks_deprecated:
+    runs-on: ubuntu-latest
+    name: Test include-checks is warned about, not applied
+    env:
+      OASDIFF_ACTION_TEST_EXPECTED_OUTPUT: "1 changes: 1 error, 0 warning, 0 info"
+    steps:
+      - name: checkout
+        uses: actions/checkout@v7
+      # include-checks is ignored by oasdiff. The action must not pass it on and
+      # must not change the result; it only warns. Passing a name that is not a
+      # real check would fail the run if the action still forwarded it.
+      - name: Running breaking action with include-checks
+        id: test_include_checks
+        continue-on-error: true
+        uses: ./breaking
+        with:
+          base: 'specs/base.yaml'
+          revision: 'specs/revision-breaking.yaml'
+          include-checks: 'not-a-real-check'
+      - name: Assert the run was unaffected
+        run: |
+          delimiter=$(cat /proc/sys/kernel/random/uuid | tr -d '-')
+          output=$(cat <<-$delimiter
+          ${{ steps.test_include_checks.outputs.breaking }}
+          $delimiter
+          )
+          if [ "$output" != "$OASDIFF_ACTION_TEST_EXPECTED_OUTPUT" ]; then
+            echo "Expected output '$OASDIFF_ACTION_TEST_EXPECTED_OUTPUT' (include-checks must be ignored, not forwarded) but got '$output'" >&2
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ jobs:
 | `base` | — (required) | Path to the base (old) OpenAPI spec | file path, URL, git ref |
 | `revision` | — (required) | Path to the revised (new) OpenAPI spec | file path, URL, git ref |
 | `fail-on` | `''` | Fail with exit code 1 if changes are found at or above this severity | `ERR`, `WARN` |
-| `include-checks` | `''` | Include optional breaking change checks | check names (comma-separated) |
+| `include-checks` | `''` | **Deprecated and ignored.** oasdiff retired the optional-checks mechanism; set `severity-levels` in `.oasdiff.yaml` instead. Setting it emits a warning annotation and has no effect | — |
 | `include-path-params` | `false` | Include path parameter names in endpoint matching | `true`, `false` |
 | `deprecation-days-beta` | `31` | Minimum sunset period (days) for deprecation of beta API endpoints | integer |
 | `deprecation-days-stable` | `180` | Minimum sunset period (days) for deprecation of stable API endpoints | integer |
@@ -237,6 +237,15 @@ exclude-elements:
   - title
   - summary
 err-ignore: ./oasdiff-err-ignore.txt
+severity-levels: ./oasdiff-levels.txt
+```
+
+`severity-levels` points at a file that overrides the severity of individual checks, one `check-id level` per line, where level is `err`, `warn`, `info` or `none`. Raise a check to `err` (with `fail-on: ERR`) to make it fail the build, or set it to `none` to silence it:
+
+```
+# oasdiff-levels.txt
+api-version-not-bumped          err
+api-major-version-not-bumped    err
 ```
 
 The actions read this file from the runner's `$GITHUB_WORKSPACE` (which `actions/checkout` populates), so no extra steps are needed.

--- a/breaking/action.yml
+++ b/breaking/action.yml
@@ -12,7 +12,7 @@ inputs:
     required: false
     default: ''
   include-checks:
-    description: 'Include any of the defined optional breaking changes checks'
+    description: 'Deprecated and ignored: oasdiff retired the optional-checks mechanism. To make a check fail the build, set severity-levels in .oasdiff.yaml.'
     required: false
   include-path-params:
     description: 'Include path parameter names in endpoint matching'

--- a/breaking/entrypoint.sh
+++ b/breaking/entrypoint.sh
@@ -148,7 +148,7 @@ if [ "$include_path_params" = "true" ]; then
     flags="$flags --include-path-params"
 fi
 if [ -n "$include_checks" ]; then
-    flags="$flags --include-checks $include_checks"
+    echo "::warning::oasdiff: 'include-checks' is ignored, the optional-checks mechanism it drove was retired. To make a check fail the build, add 'severity-levels: <file>' to .oasdiff.yaml, listing the check id with level 'err', and set 'fail-on: ERR'."
 fi
 if [ -n "$deprecation_days_beta" ]; then
     flags="$flags --deprecation-days-beta $deprecation_days_beta"

--- a/specs/severity-levels.txt
+++ b/specs/severity-levels.txt
@@ -1,0 +1,1 @@
+api-removed-without-deprecation	info


### PR DESCRIPTION
Closes #196.

## The bug

oasdiff retired the optional-checks mechanism `include-checks` drove, and now ignores the flag:

```
"include-checks": "it is now ignored; use --severity-levels to enforce a check as breaking"
```

The actions still advertised it as functional. So the documented way to enforce a check did nothing at all: the user believes a check is enforced, no error appears, and it never fires. Silence is the worst of the available failure modes, and it is the whole of the bug.

## The fix

The action no longer forwards the flag, and emits a warning annotation instead:

```
::warning::oasdiff: 'include-checks' is ignored, the optional-checks mechanism it drove was
retired. To make a check fail the build, add 'severity-levels: <file>' to .oasdiff.yaml,
listing the check id with level 'err', and set 'fail-on: ERR'.
```

The input itself stays, so workflows that pass it today keep working rather than failing on an unknown input. Forwarding it was pointless (oasdiff ignores it) and would break outright if the flag is ever removed rather than merely ignored.

## Why there is no `severity-levels` input

#196 proposed adding one. It is deliberately not here.

`.oasdiff.yaml` is the configuration surface these actions converge on, and the inputs are a deliberate subset, not an aspiration to cover the flag set. Counting `breaking`:

| | count | examples |
|---|---|---|
| oasdiff flags **with** an input | 10 | `fail-on`, `composed`, `err-ignore` |
| oasdiff flags **without** | 20 | `auto-upgrade`, `stability-level`, `match-path`, `prefix-base`, `format`, `lang`, `template` |

So not having an input is the norm. `severity-levels` already worked through the config file before this PR, needing no code at all, and adding an input would grow a surface we intend to stop growing. It would also add another positional argument, in a scheme where a mis-ordered index corrupts a run silently rather than erroring.

The deprecation message and the README therefore teach the config file:

```yaml
# .oasdiff.yaml
severity-levels: ./oasdiff-levels.txt
fail-on: ERR
```

```
# oasdiff-levels.txt
api-version-not-bumped          err
api-major-version-not-bumped    err
```

That is the recipe #154 needed.

## Tests

- **`severity-levels` via `.oasdiff.yaml`** — downgrades `api-removed-without-deprecation` (this repo's only breaking finding on the test specs) to `info`, and asserts `fail-on: ERR` stops failing. Sits alongside the existing yaml-config jobs for `fail-on` and `err-ignore`, so the config path is pinned rather than assumed.
- **`include-checks`** — passes `not-a-real-check` and asserts the run is unaffected. This fails if the action ever forwards the input again, since oasdiff would reject the name.

Also verified by running the entrypoint against a stubbed `oasdiff` that logs its argv: neither `--include-checks` nor `--severity-levels` reaches the CLI, and the annotation is emitted.
